### PR TITLE
docs: add TakoAPI directory badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,9 @@ The system is built around three boundaries:
 ```bash
 uv pip install everos
 # or: pip install everos
+
+[![Listed on TakoAPI](https://img.shields.io/badge/Listed%20on-TakoAPI-7c3aed)](https://takoapi.com/agents/evermind-ai-everos)
+
 ```
 
 ### 2. Initialize Configuration


### PR DESCRIPTION
Hi! 👋 **EverOS** is listed in the [TakoAPI](https://takoapi.com) open agent directory — a free, open catalog that helps people discover AI-agent projects ("one API to discover all agents").

Your listing: https://takoapi.com/agents/evermind-ai-everos

This PR adds a small badge near the top of the README that links back to that listing, so visitors can find the directory entry. It's entirely optional — if you'd prefer not to include it, just close this PR (no hard feelings, and apologies for the noise).

No tracking and no obligations. Thanks for building EverOS! 🙏