### PR TITLE
feat(api): expose cascade queue counters in /health (#364)

### DIFF
--- a/src/everos/entrypoints/api/routes/health.py
+++ b/src/everos/entrypoints/api/routes/health.py
@@ -11,6 +11,10 @@ from everos.component.embedding import get_embedding_capability
 from everos.component.multimodal import get_multimodal_llm_capability
 from everos.component.parser import parser_available
 from everos.component.rerank import get_rerank_capability
+from everos.core.observability.logging import get_logger
+from everos.infra.persistence.sqlite import md_change_state_repo
+
+logger = get_logger(__name__)
 
 router = APIRouter(tags=["health"])
 
@@ -29,6 +33,29 @@ class HealthCapabilities(BaseModel):
     parser: bool
 
 
+class HealthCascade(BaseModel):
+    """Cascade queue counters, mirroring ``cascade status`` (#364).
+
+    Writes land in markdown first and are indexed later by the cascade
+    worker, so a successful ``/memory/flush`` says nothing about whether
+    the row reached the index. When the worker is stuck, the write path
+    keeps returning ``extracted`` while nothing is queryable — the outage
+    stays invisible to an HTTP host until someone reads the server log.
+
+    These counters already existed for the CLI; exposing them here gives
+    an API host the same probe the CLI has. ``failed_permanent > 0``
+    means rows are terminally stuck: no retry will clear them, and the
+    operator has to run ``cascade fix`` / ``cascade rebuild``.
+    """
+
+    pending: int
+    done: int
+    failed_retryable: int
+    failed_permanent: int
+    lag: int
+    """``max_lsn - last_processed_lsn`` — how far indexing trails writes."""
+
+
 class HealthResponse(BaseModel):
     """Response schema for ``GET /health``.
 
@@ -43,11 +70,37 @@ class HealthResponse(BaseModel):
     version: str
     capabilities: HealthCapabilities
     disabled_features: list[str]
+    cascade: HealthCascade | None = None
+    """``None`` when queue state is unreadable — see ``_cascade_health``."""
+
+
+async def _cascade_health() -> HealthCascade | None:
+    """Queue counters, or ``None`` if they cannot be read.
+
+    ``/health`` is a liveness probe: it must answer even when the
+    metadata store is unavailable, so a failure here degrades the
+    payload instead of the endpoint. ``None`` is deliberately distinct
+    from all-zero counters — "unknown" and "queue is clean" are
+    different facts, and a host that treats them alike would report a
+    dead queue as healthy.
+    """
+    try:
+        summary = await md_change_state_repo.queue_summary()
+    except Exception:
+        logger.warning("health.cascade.unavailable", exc_info=True)
+        return None
+    return HealthCascade(
+        pending=summary.pending,
+        done=summary.done,
+        failed_retryable=summary.failed_retryable,
+        failed_permanent=summary.failed_permanent,
+        lag=max(0, summary.max_lsn - summary.last_processed_lsn),
+    )
 
 
 @router.get("/health", response_model=HealthResponse)
 async def health() -> HealthResponse:
-    """Liveness probe with capabilities and disabled features."""
+    """Liveness probe with capabilities, disabled features and queue state."""
     # ``llm`` is hardcoded ``True`` — kept for symmetry with the caps
     # dict rather than probed live. Rationale: LLM is a Tier-1 hard
     # requirement enforced at startup by ``LLMLifespanProvider``
@@ -70,4 +123,5 @@ async def health() -> HealthResponse:
         version=__version__,
         capabilities=caps,
         disabled_features=compute_disabled_features(caps.model_dump()),
+        cascade=await _cascade_health(),
     )

--- a/tests/unit/test_entrypoints/test_api/test_routes/test_health_cascade.py
+++ b/tests/unit/test_entrypoints/test_api/test_routes/test_health_cascade.py
@@ -1,0 +1,92 @@
+"""Pins the cascade section of ``GET /health`` (#364).
+
+Contract under test: an HTTP host must be able to detect that memory
+writes are landing in markdown but no longer reaching the index. The
+write path is deliberately decoupled from indexing, so ``/memory/flush``
+keeps answering ``extracted`` while the cascade worker is stuck — the
+counters here are the only signal an API-only host gets.
+
+Two facts are pinned:
+
+* terminal failures surface as ``failed_permanent`` and the LSN gap
+  surfaces as ``lag``, so a host can alert on either;
+* an unreadable queue yields ``cascade: null`` rather than a 500 or
+  all-zero counters — ``/health`` stays a liveness probe, and "unknown"
+  must not be mistaken for "clean".
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from everos.entrypoints.api.routes import health as health_route
+from everos.infra.persistence.sqlite.repos.md_change_state import QueueSummary
+
+
+async def test_cascade_counters_surface_terminal_failures(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A stuck queue is visible: failed_permanent and lag are reported."""
+
+    async def fake_summary() -> QueueSummary:
+        return QueueSummary(
+            pending=3,
+            done=41,
+            failed_retryable=2,
+            failed_permanent=7,
+            max_lsn=50,
+            last_processed_lsn=44,
+        )
+
+    monkeypatch.setattr(
+        health_route.md_change_state_repo, "queue_summary", fake_summary
+    )
+
+    cascade = await health_route._cascade_health()
+
+    assert cascade is not None
+    assert cascade.failed_permanent == 7
+    assert cascade.failed_retryable == 2
+    assert cascade.pending == 3
+    assert cascade.done == 41
+    assert cascade.lag == 6
+
+
+async def test_lag_never_goes_negative(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A processed LSN ahead of max reports zero lag, not a negative number."""
+
+    async def fake_summary() -> QueueSummary:
+        return QueueSummary(
+            pending=0,
+            done=10,
+            failed_retryable=0,
+            failed_permanent=0,
+            max_lsn=5,
+            last_processed_lsn=9,
+        )
+
+    monkeypatch.setattr(
+        health_route.md_change_state_repo, "queue_summary", fake_summary
+    )
+
+    cascade = await health_route._cascade_health()
+
+    assert cascade is not None
+    assert cascade.lag == 0
+
+
+async def test_unreadable_queue_degrades_to_null(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When queue state cannot be read, the probe degrades instead of failing.
+
+    ``None`` rather than zeros: a host must not read "unknown" as "clean",
+    which is the exact confusion that let the original outage hide.
+    """
+
+    async def boom() -> QueueSummary:
+        raise RuntimeError("lance error: LanceError(IO)")
+
+    monkeypatch.setattr(health_route.md_change_state_repo, "queue_summary", boom)
+
+    assert await health_route._cascade_health() is None


### PR DESCRIPTION
## Summary

Closes part 1 of #364 — the half that makes the failure invisible rather than the half that causes it.

An HTTP host currently cannot tell that memory writes stopped reaching the index. Writes land in markdown and are indexed later by the cascade worker, so `/memory/flush` keeps answering `"extracted"` while the worker is stuck. In #364 that hid an 18-day episode outage: the write API returned success, recall still served older rows, and the fail-open host drew green traces over all of it.

I deliberately did **not** widen `flush`'s return type to `partial` / `degraded`, as the issue first suggested. `flush` isn't lying inside its own layer — it reports on the markdown write, which did succeed. Making it report on indexing would couple the write path to the cascade stage the architecture separates on purpose.

Instead: the counters already exist. `queue_summary()` computes `pending`, `done`, `failed_retryable`, `failed_permanent`, and `cascade status` prints all of them. They simply had no HTTP exit — a CLI operator could see the outage, an API host could not. That asymmetry is the defect this PR closes.

**What changed**

- `GET /health` gains an additive `cascade` section with the four existing counters plus `lag` (`max_lsn - last_processed_lsn`, the same figure the CLI derives).
- No existing field changes meaning, so the endpoint contract holds.
- When queue state is unreadable, `cascade` is `null` rather than zeroed. `/health` is a liveness probe and must answer even when the metadata store is down — and "unknown" must not read as "clean", which is precisely the confusion that let the original outage hide.

A host can now probe actively: `failed_permanent > 0` means rows are terminally stuck, no retry will clear them, and an operator has to run `cascade fix` / `cascade rebuild`.

Part 2 of the issue (no retry ceiling) is **not** addressed here. The `except Exception` branch already marks unrecoverable rows terminal via `mark_failed(retryable=False)`, so 330 identical log lines for the same entries point at re-enqueueing from elsewhere — most likely the scanner re-observing the same md files by mtime — rather than an unbounded retry loop. That deserves a reproduction before a patch, and it doesn't belong in the same change.

## Area

- [x] Developer experience
- [ ] Architecture method
- [ ] Benchmark
- [ ] Use case
- [ ] Documentation
- [ ] CI, build, or release

## Verification

```text
$ uv run pytest tests/unit/test_entrypoints/test_api/test_routes/test_health_cascade.py -v
test_cascade_counters_surface_terminal_failures PASSED
test_lag_never_goes_negative                    PASSED
test_unreadable_queue_degrades_to_null          PASSED
3 passed in 6.29s

$ uv run pytest tests/unit/test_entrypoints/ tests/integration/test_api/test_health_capabilities.py -q
220 passed in 102.84s

$ uv run ruff check src/everos/entrypoints/api/routes/health.py tests/.../test_health_cascade.py
All checks passed!

$ uv run ruff format --check <same files>
2 files already formatted
```

The new test pins three facts: terminal failures surface as `failed_permanent` with the LSN gap as `lag`; `lag` never goes negative; and an unreadable queue degrades to `null` instead of raising or reporting zeros.

Existing `/health` tests pass untouched.
