### PR TITLE
docs: reorganize EverMind ecosystem

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@
 - [Quick Start](#quick-start)
 - [Use Cases](#use-cases)
 - [Documentation](#documentation)
-- [EverMind Ecosystems](#evermind-ecosystems)
+- [EverMind Ecosystem](#evermind-ecosystem)
 - [Contributing](#contributing)
 
 <br>
@@ -641,50 +641,45 @@ Explore stored entities and relationships in a graph interface. Frontend demo; b
 
 </div>
 
-## EverMind Ecosystems
+## EverMind Ecosystem
 
-EverMind is an open-source ecosystem for long-term memory, self-evolving
-agents, AI-native interfaces, and memory evaluation.
+EverMind connects memory research, production-ready products, and practical
+integrations into one open-source ecosystem.
 
-<table>
-<tr>
-<th colspan="2">EverMind Open-Source Ecosystem</th>
-</tr>
-<tr>
-<td><strong>Memory Runtime</strong></td>
-<td><a href="https://github.com/EverMind-AI/EverOS">EverOS</a> - the local memory operating system and research-backed runtime for agent and user memory.</td>
-</tr>
-<tr>
-<td><strong>Self-Improving Agent Harness</strong></td>
-<td><a href="https://github.com/EverMind-AI/Raven">Raven</a> - the self-improving agent harness that brings memory, proactivity, context control, and skill evolution into terminal-native agents.</td>
-</tr>
-<tr>
-<td><strong>Algorithm Engine</strong></td>
-<td><a href="https://github.com/EverMind-AI/EverAlgo">EverAlgo</a> - stateless extraction, ranking, parsing, and memory operators that power EverOS.</td>
-</tr>
-<tr>
-<td><strong>Hypergraph Memory</strong></td>
-<td><a href="https://github.com/EverMind-AI/HyperMem">HyperMem</a> - hypergraph memory for long-term conversations, with its own benchmark-backed topic -> episode -> fact retrieval method.</td>
-</tr>
-<tr>
-<td><strong>Benchmarks</strong></td>
-<td><a href="https://github.com/EverMind-AI/EverMemBench">EverMemBench</a> · <a href="https://github.com/EverMind-AI/EvoAgentBench">EvoAgentBench</a> - evaluation suites for conversational memory and agent self-evolution.</td>
-</tr>
-<tr>
-<td><strong>Long-Context Research</strong></td>
-<td><a href="https://github.com/EverMind-AI/MSA">MSA</a> - Memory Sparse Attention for scalable latent memory and 100M-token contexts.</td>
-</tr>
-<tr>
-<td><strong>Personal Memory Layer</strong></td>
-<td><a href="https://github.com/EverMind-AI/EverMe">EverMe</a> - CLI and agent plugin suite for cross-device, cross-agent personal memory.</td>
-</tr>
-<tr>
-<td><strong>Developer Integrations</strong></td>
-<td><a href="https://github.com/EverMind-AI/evermem-claude-code">evermem-claude-code</a> · <a href="https://github.com/EverMind-AI/everos-plugins">everos-plugins</a> - plugins, skills, and migration tooling for AI coding agents.</td>
-</tr>
-</table>
+### Products
 
-Together, these repositories form EverMind's research-to-runtime stack: new memory methods, reusable algorithms, benchmark evidence, and practical agent integrations.
+| Project | Role |
+|---|---|
+| [EverOS](https://github.com/EverMind-AI/EverOS) | A local-first, Markdown-native long-term memory runtime for agents and users. |
+| [Raven](https://github.com/EverMind-AI/Raven) | A memory-first, self-improving agent harness with proactivity, context control, and skill evolution. |
+| [EverMe](https://github.com/EverMind-AI/EverMe) | A CLI and agent plugin suite for cross-device, cross-agent personal memory. |
+
+### Research & Evaluation
+
+| Project | Focus |
+|---|---|
+| [SkillCorpus](https://github.com/EverMind-AI/SkillCorpus) | Curated, retrieval-ready agent skill corpora with retrieval and evaluation tooling. |
+| [EverAlgo](https://github.com/EverMind-AI/EverAlgo) | Stateless extraction, ranking, parsing, and memory operators that power EverOS. |
+| [HyperMem](https://github.com/EverMind-AI/HyperMem) | Hypergraph-based hierarchical memory for coarse-to-fine long-term conversation retrieval. |
+| [MSA](https://github.com/EverMind-AI/MSA) | Memory Sparse Attention for scalable latent memory and 100M-token contexts. |
+| [EverMemBench](https://github.com/EverMind-AI/EverMemBench) | Evaluation of factual recall, applied reasoning, and personalized generalization in memory systems. |
+| [EvoAgentBench](https://github.com/EverMind-AI/EvoAgentBench) | Longitudinal evaluation of agent self-evolution, transfer efficiency, error avoidance, and skill use. |
+
+### Integrations
+
+Official integrations are maintained in the
+[EverMind plugins repository](https://github.com/EverMind-AI/plugins).
+
+| Platform | EverOS integration |
+|---|---|
+| [OpenClaw](https://docs.openclaw.ai) | [OpenClaw plugin](https://github.com/EverMind-AI/plugins/tree/main/openclaw) for automatic recall, capture, and session-memory lifecycle management. |
+| [Hermes Agent](https://github.com/NousResearch/hermes-agent) | [Hermes plugin](https://github.com/EverMind-AI/plugins/tree/main/hermes) for persistent memory across Hermes sessions. |
+| [DeepSeek Harness](https://github.com/deepseek-ai/DeepSeek-Harness) | [DSH plugin](https://github.com/EverMind-AI/plugins/tree/main/dsh) for memory-aware DeepSeek Harness agents. |
+| [Dify](https://dify.ai) | [Self-hosted](https://github.com/EverMind-AI/plugins/tree/main/dify) and [cloud](https://github.com/EverMind-AI/plugins/tree/main/dify_cloud) tools for explicit memory search and storage in workflows and agents. |
+
+Together, these projects form EverMind's research-to-runtime stack: methods
+and benchmarks become reusable memory infrastructure, products, and agent
+integrations.
 
 <br>
 <div align="right">

--- a/README.md
+++ b/README.md
@@ -646,36 +646,73 @@ Explore stored entities and relationships in a graph interface. Frontend demo; b
 EverMind connects memory research, production-ready products, and practical
 integrations into one open-source ecosystem.
 
-### Products
-
-| Project | Role |
-|---|---|
-| [EverOS](https://github.com/EverMind-AI/EverOS) | A local-first, Markdown-native long-term memory runtime for agents and users. |
-| [Raven](https://github.com/EverMind-AI/Raven) | A memory-first, self-improving agent harness with proactivity, context control, and skill evolution. |
-| [EverMe](https://github.com/EverMind-AI/EverMe) | A CLI and agent plugin suite for cross-device, cross-agent personal memory. |
-
-### Research & Evaluation
-
-| Project | Focus |
-|---|---|
-| [SkillCorpus](https://github.com/EverMind-AI/SkillCorpus) | Curated, retrieval-ready agent skill corpora with retrieval and evaluation tooling. |
-| [EverAlgo](https://github.com/EverMind-AI/EverAlgo) | Stateless extraction, ranking, parsing, and memory operators that power EverOS. |
-| [HyperMem](https://github.com/EverMind-AI/HyperMem) | Hypergraph-based hierarchical memory for coarse-to-fine long-term conversation retrieval. |
-| [MSA](https://github.com/EverMind-AI/MSA) | Memory Sparse Attention for scalable latent memory and 100M-token contexts. |
-| [EverMemBench](https://github.com/EverMind-AI/EverMemBench) | Evaluation of factual recall, applied reasoning, and personalized generalization in memory systems. |
-| [EvoAgentBench](https://github.com/EverMind-AI/EvoAgentBench) | Longitudinal evaluation of agent self-evolution, transfer efficiency, error avoidance, and skill use. |
-
-### Integrations
-
-Official integrations are maintained in the
-[EverMind plugins repository](https://github.com/EverMind-AI/plugins).
-
-| Platform | EverOS integration |
-|---|---|
-| [OpenClaw](https://docs.openclaw.ai) | [OpenClaw plugin](https://github.com/EverMind-AI/plugins/tree/main/openclaw) for automatic recall, capture, and session-memory lifecycle management. |
-| [Hermes Agent](https://github.com/NousResearch/hermes-agent) | [Hermes plugin](https://github.com/EverMind-AI/plugins/tree/main/hermes) for persistent memory across Hermes sessions. |
-| [DeepSeek Harness](https://github.com/deepseek-ai/DeepSeek-Harness) | [DSH plugin](https://github.com/EverMind-AI/plugins/tree/main/dsh) for memory-aware DeepSeek Harness agents. |
-| [Dify](https://dify.ai) | [Self-hosted](https://github.com/EverMind-AI/plugins/tree/main/dify) and [cloud](https://github.com/EverMind-AI/plugins/tree/main/dify_cloud) tools for explicit memory search and storage in workflows and agents. |
+<table>
+<tr>
+<th colspan="2">Products</th>
+</tr>
+<tr>
+<td><strong><a href="https://github.com/EverMind-AI/EverOS">EverOS</a></strong></td>
+<td>A local-first, Markdown-native long-term memory runtime for agents and users.</td>
+</tr>
+<tr>
+<td><strong><a href="https://github.com/EverMind-AI/Raven">Raven</a></strong></td>
+<td>A memory-first, self-improving agent harness with proactivity, context control, and skill evolution.</td>
+</tr>
+<tr>
+<td><strong><a href="https://github.com/EverMind-AI/EverMe">EverMe</a></strong></td>
+<td>A CLI and agent plugin suite for cross-device, cross-agent personal memory.</td>
+</tr>
+<tr>
+<th colspan="2">Research &amp; Evaluation</th>
+</tr>
+<tr>
+<td><strong><a href="https://github.com/EverMind-AI/SkillCorpus">SkillCorpus</a></strong></td>
+<td>Curated, retrieval-ready agent skill corpora with retrieval and evaluation tooling.</td>
+</tr>
+<tr>
+<td><strong><a href="https://github.com/EverMind-AI/EverAlgo">EverAlgo</a></strong></td>
+<td>Stateless extraction, ranking, parsing, and memory operators that power EverOS.</td>
+</tr>
+<tr>
+<td><strong><a href="https://github.com/EverMind-AI/HyperMem">HyperMem</a></strong></td>
+<td>Hypergraph-based hierarchical memory for coarse-to-fine long-term conversation retrieval.</td>
+</tr>
+<tr>
+<td><strong><a href="https://github.com/EverMind-AI/MSA">MSA</a></strong></td>
+<td>Memory Sparse Attention for scalable latent memory and 100M-token contexts.</td>
+</tr>
+<tr>
+<td><strong><a href="https://github.com/EverMind-AI/EverMemBench">EverMemBench</a></strong></td>
+<td>Evaluation of factual recall, applied reasoning, and personalized generalization in memory systems.</td>
+</tr>
+<tr>
+<td><strong><a href="https://github.com/EverMind-AI/EvoAgentBench">EvoAgentBench</a></strong></td>
+<td>Longitudinal evaluation of agent self-evolution, transfer efficiency, error avoidance, and skill use.</td>
+</tr>
+<tr>
+<th colspan="2">Integrations</th>
+</tr>
+<tr>
+<td><strong><a href="https://docs.openclaw.ai">OpenClaw</a></strong></td>
+<td><a href="https://github.com/EverMind-AI/plugins/tree/main/openclaw">OpenClaw plugin</a> for automatic recall, capture, and session-memory lifecycle management.</td>
+</tr>
+<tr>
+<td><strong><a href="https://github.com/NousResearch/hermes-agent">Hermes Agent</a></strong></td>
+<td><a href="https://github.com/EverMind-AI/plugins/tree/main/hermes">Hermes plugin</a> for persistent memory across Hermes sessions.</td>
+</tr>
+<tr>
+<td><strong><a href="https://github.com/deepseek-ai/DeepSeek-Harness">DeepSeek Harness</a></strong></td>
+<td><a href="https://github.com/EverMind-AI/plugins/tree/main/dsh">DSH plugin</a> for memory-aware DeepSeek Harness agents.</td>
+</tr>
+<tr>
+<td><strong><a href="https://dify.ai">Dify</a></strong></td>
+<td><a href="https://github.com/EverMind-AI/plugins/tree/main/dify">Self-hosted</a> and <a href="https://github.com/EverMind-AI/plugins/tree/main/dify_cloud">cloud</a> tools for explicit memory search and storage in workflows and agents.</td>
+</tr>
+<tr>
+<td><strong>Integration Hub</strong></td>
+<td>Browse all official integrations in the <a href="https://github.com/EverMind-AI/plugins">EverMind plugins repository</a>.</td>
+</tr>
+</table>
 
 Together, these projects form EverMind's research-to-runtime stack: methods
 and benchmarks become reusable memory infrastructure, products, and agent

--- a/README.md
+++ b/README.md
@@ -659,7 +659,7 @@ integrations into one open-source ecosystem.
 <td>A memory-first, self-improving agent harness with proactivity, context control, and skill evolution.</td>
 </tr>
 <tr>
-<td><strong><a href="https://github.com/EverMind-AI/EverMe">EverMe</a></strong></td>
+<td><strong><a href="https://github.com/EverMind-AI/EverMe">EverMe (CLI)</a></strong></td>
 <td>A CLI and agent plugin suite for cross-device, cross-agent personal memory.</td>
 </tr>
 <tr>

--- a/README.md
+++ b/README.md
@@ -690,7 +690,7 @@ integrations into one open-source ecosystem.
 <td>Longitudinal evaluation of agent self-evolution, transfer efficiency, error avoidance, and skill use.</td>
 </tr>
 <tr>
-<th colspan="2">Integrations</th>
+<th colspan="2"><a href="https://github.com/EverMind-AI/plugins">Integrations</a></th>
 </tr>
 <tr>
 <td><strong><a href="https://docs.openclaw.ai">OpenClaw</a></strong></td>
@@ -707,10 +707,6 @@ integrations into one open-source ecosystem.
 <tr>
 <td><strong><a href="https://dify.ai">Dify</a></strong></td>
 <td><a href="https://github.com/EverMind-AI/plugins/tree/main/dify">Self-hosted</a> and <a href="https://github.com/EverMind-AI/plugins/tree/main/dify_cloud">cloud</a> tools for explicit memory search and storage in workflows and agents.</td>
-</tr>
-<tr>
-<td><strong>Integration Hub</strong></td>
-<td>Browse all official integrations in the <a href="https://github.com/EverMind-AI/plugins">EverMind plugins repository</a>.</td>
 </tr>
 </table>
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -644,36 +644,73 @@ Claude Code 的持久记忆插件。自动保存并回忆过去 coding sessions 
 
 EverMind 将记忆研究、可直接使用的产品与实际集成连接为一个开源生态。
 
-### 产品
-
-| 项目 | 定位 |
-|---|---|
-| [EverOS](https://github.com/EverMind-AI/EverOS) | 本地优先、Markdown 原生的 Agent 与用户长期记忆运行时。 |
-| [Raven](https://github.com/EverMind-AI/Raven) | 以记忆为核心的自进化 Agent Harness，具备主动性、上下文控制与 Skill 进化能力。 |
-| [EverMe](https://github.com/EverMind-AI/EverMe) | 面向跨设备、跨 Agent 个人记忆的 CLI 与 Agent 插件套件。 |
-
-### 研究与评测
-
-| 项目 | 研究方向 |
-|---|---|
-| [SkillCorpus](https://github.com/EverMind-AI/SkillCorpus) | 将分散的 Agent Skill 整理为可检索语料库，并提供检索与评测工具。 |
-| [EverAlgo](https://github.com/EverMind-AI/EverAlgo) | 为 EverOS 提供无状态的提取、排序、解析与记忆算法。 |
-| [HyperMem](https://github.com/EverMind-AI/HyperMem) | 基于超图的分层记忆架构，用于由粗到细的长期对话检索。 |
-| [MSA](https://github.com/EverMind-AI/MSA) | 面向可扩展潜在记忆与一亿 Token 上下文的 Memory Sparse Attention。 |
-| [EverMemBench](https://github.com/EverMind-AI/EverMemBench) | 从事实召回、应用推理和个性化泛化三个层面评测记忆系统。 |
-| [EvoAgentBench](https://github.com/EverMind-AI/EvoAgentBench) | 纵向评测 Agent 自进化、迁移效率、错误规避和 Skill 使用能力。 |
-
-### 插件与集成
-
-官方集成统一维护在
-[EverMind plugins 仓库](https://github.com/EverMind-AI/plugins)。
-
-| 平台 | EverOS 集成 |
-|---|---|
-| [OpenClaw](https://docs.openclaw.ai) | [OpenClaw 插件](https://github.com/EverMind-AI/plugins/tree/main/openclaw)，自动管理召回、写入与会话记忆生命周期。 |
-| [Hermes Agent](https://github.com/NousResearch/hermes-agent) | [Hermes 插件](https://github.com/EverMind-AI/plugins/tree/main/hermes)，为 Hermes 会话提供持久记忆。 |
-| [DeepSeek Harness](https://github.com/deepseek-ai/DeepSeek-Harness) | [DSH 插件](https://github.com/EverMind-AI/plugins/tree/main/dsh)，让 DeepSeek Harness Agent 使用长期记忆。 |
-| [Dify](https://dify.ai) | [本地版](https://github.com/EverMind-AI/plugins/tree/main/dify)与[云端版](https://github.com/EverMind-AI/plugins/tree/main/dify_cloud)工具，在工作流和 Agent 中显式搜索与写入记忆。 |
+<table>
+<tr>
+<th colspan="2">产品</th>
+</tr>
+<tr>
+<td><strong><a href="https://github.com/EverMind-AI/EverOS">EverOS</a></strong></td>
+<td>本地优先、Markdown 原生的 Agent 与用户长期记忆运行时。</td>
+</tr>
+<tr>
+<td><strong><a href="https://github.com/EverMind-AI/Raven">Raven</a></strong></td>
+<td>以记忆为核心的自进化 Agent Harness，具备主动性、上下文控制与 Skill 进化能力。</td>
+</tr>
+<tr>
+<td><strong><a href="https://github.com/EverMind-AI/EverMe">EverMe</a></strong></td>
+<td>面向跨设备、跨 Agent 个人记忆的 CLI 与 Agent 插件套件。</td>
+</tr>
+<tr>
+<th colspan="2">研究与评测</th>
+</tr>
+<tr>
+<td><strong><a href="https://github.com/EverMind-AI/SkillCorpus">SkillCorpus</a></strong></td>
+<td>将分散的 Agent Skill 整理为可检索语料库，并提供检索与评测工具。</td>
+</tr>
+<tr>
+<td><strong><a href="https://github.com/EverMind-AI/EverAlgo">EverAlgo</a></strong></td>
+<td>为 EverOS 提供无状态的提取、排序、解析与记忆算法。</td>
+</tr>
+<tr>
+<td><strong><a href="https://github.com/EverMind-AI/HyperMem">HyperMem</a></strong></td>
+<td>基于超图的分层记忆架构，用于由粗到细的长期对话检索。</td>
+</tr>
+<tr>
+<td><strong><a href="https://github.com/EverMind-AI/MSA">MSA</a></strong></td>
+<td>面向可扩展潜在记忆与一亿 Token 上下文的 Memory Sparse Attention。</td>
+</tr>
+<tr>
+<td><strong><a href="https://github.com/EverMind-AI/EverMemBench">EverMemBench</a></strong></td>
+<td>从事实召回、应用推理和个性化泛化三个层面评测记忆系统。</td>
+</tr>
+<tr>
+<td><strong><a href="https://github.com/EverMind-AI/EvoAgentBench">EvoAgentBench</a></strong></td>
+<td>纵向评测 Agent 自进化、迁移效率、错误规避和 Skill 使用能力。</td>
+</tr>
+<tr>
+<th colspan="2">插件与集成</th>
+</tr>
+<tr>
+<td><strong><a href="https://docs.openclaw.ai">OpenClaw</a></strong></td>
+<td><a href="https://github.com/EverMind-AI/plugins/tree/main/openclaw">OpenClaw 插件</a>，自动管理召回、写入与会话记忆生命周期。</td>
+</tr>
+<tr>
+<td><strong><a href="https://github.com/NousResearch/hermes-agent">Hermes Agent</a></strong></td>
+<td><a href="https://github.com/EverMind-AI/plugins/tree/main/hermes">Hermes 插件</a>，为 Hermes 会话提供持久记忆。</td>
+</tr>
+<tr>
+<td><strong><a href="https://github.com/deepseek-ai/DeepSeek-Harness">DeepSeek Harness</a></strong></td>
+<td><a href="https://github.com/EverMind-AI/plugins/tree/main/dsh">DSH 插件</a>，让 DeepSeek Harness Agent 使用长期记忆。</td>
+</tr>
+<tr>
+<td><strong><a href="https://dify.ai">Dify</a></strong></td>
+<td><a href="https://github.com/EverMind-AI/plugins/tree/main/dify">本地版</a>与<a href="https://github.com/EverMind-AI/plugins/tree/main/dify_cloud">云端版</a>工具，在工作流和 Agent 中显式搜索与写入记忆。</td>
+</tr>
+<tr>
+<td><strong>集成中心</strong></td>
+<td>在 <a href="https://github.com/EverMind-AI/plugins">EverMind plugins 仓库</a>浏览全部官方集成。</td>
+</tr>
+</table>
 
 这些项目共同构成 EverMind 从研究到运行时的完整链路：将方法与评测转化为
 可复用的记忆基础设施、产品和 Agent 集成。

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -642,48 +642,41 @@ Claude Code 的持久记忆插件。自动保存并回忆过去 coding sessions 
 
 ## EverMind 生态
 
-EverMind 是一个面向长期记忆、自进化 Agent、AI-native interfaces 和记忆评测的开源生态。
+EverMind 将记忆研究、可直接使用的产品与实际集成连接为一个开源生态。
 
-<table>
-<tr>
-<th colspan="2">EverMind 开源生态</th>
-</tr>
-<tr>
-<td><strong>Memory Runtime</strong></td>
-<td><a href="https://github.com/EverMind-AI/EverOS">EverOS</a> - 本地记忆操作系统，以及有研究支撑的 Agent 和用户记忆 runtime。</td>
-</tr>
-<tr>
-<td><strong>Self-Improving Agent Harness</strong></td>
-<td><a href="https://github.com/EverMind-AI/Raven">Raven</a> - The Self-Improving Agent Harness，把记忆、主动性、上下文控制和 skill evolution 带进终端原生 Agent。</td>
-</tr>
-<tr>
-<td><strong>算法引擎</strong></td>
-<td><a href="https://github.com/EverMind-AI/EverAlgo">EverAlgo</a> - stateless extraction、ranking、parsing 和 memory operators，为 EverOS 提供算法能力。</td>
-</tr>
-<tr>
-<td><strong>Hypergraph Memory</strong></td>
-<td><a href="https://github.com/EverMind-AI/HyperMem">HyperMem</a> - 面向长期对话的 hypergraph memory，拥有独立的 benchmark-backed topic -> episode -> fact 检索方法。</td>
-</tr>
-<tr>
-<td><strong>Benchmarks</strong></td>
-<td><a href="https://github.com/EverMind-AI/EverMemBench">EverMemBench</a> · <a href="https://github.com/EverMind-AI/EvoAgentBench">EvoAgentBench</a> - conversational memory 和 Agent self-evolution 的评测套件。</td>
-</tr>
-<tr>
-<td><strong>Long-Context Research</strong></td>
-<td><a href="https://github.com/EverMind-AI/MSA">MSA</a> - Memory Sparse Attention，用于可扩展 latent memory 和 100M-token contexts。</td>
-</tr>
-<tr>
-<td><strong>个人记忆层</strong></td>
-<td><a href="https://github.com/EverMind-AI/EverMe">EverMe</a> - CLI 和 Agent plugin suite，用于跨设备、跨 Agent 的个人记忆。</td>
-</tr>
-<tr>
-<td><strong>开发者集成</strong></td>
-<td><a href="https://github.com/EverMind-AI/evermem-claude-code">evermem-claude-code</a> · <a href="https://github.com/EverMind-AI/everos-plugins">everos-plugins</a> - AI coding agents 的 plugins、skills 和 migration tooling。</td>
-</tr>
-</table>
+### 产品
 
-这些仓库共同构成 EverMind 的 research-to-runtime stack：新的记忆方法、
-可复用算法、benchmark evidence，以及可落地的 Agent 集成。
+| 项目 | 定位 |
+|---|---|
+| [EverOS](https://github.com/EverMind-AI/EverOS) | 本地优先、Markdown 原生的 Agent 与用户长期记忆运行时。 |
+| [Raven](https://github.com/EverMind-AI/Raven) | 以记忆为核心的自进化 Agent Harness，具备主动性、上下文控制与 Skill 进化能力。 |
+| [EverMe](https://github.com/EverMind-AI/EverMe) | 面向跨设备、跨 Agent 个人记忆的 CLI 与 Agent 插件套件。 |
+
+### 研究与评测
+
+| 项目 | 研究方向 |
+|---|---|
+| [SkillCorpus](https://github.com/EverMind-AI/SkillCorpus) | 将分散的 Agent Skill 整理为可检索语料库，并提供检索与评测工具。 |
+| [EverAlgo](https://github.com/EverMind-AI/EverAlgo) | 为 EverOS 提供无状态的提取、排序、解析与记忆算法。 |
+| [HyperMem](https://github.com/EverMind-AI/HyperMem) | 基于超图的分层记忆架构，用于由粗到细的长期对话检索。 |
+| [MSA](https://github.com/EverMind-AI/MSA) | 面向可扩展潜在记忆与一亿 Token 上下文的 Memory Sparse Attention。 |
+| [EverMemBench](https://github.com/EverMind-AI/EverMemBench) | 从事实召回、应用推理和个性化泛化三个层面评测记忆系统。 |
+| [EvoAgentBench](https://github.com/EverMind-AI/EvoAgentBench) | 纵向评测 Agent 自进化、迁移效率、错误规避和 Skill 使用能力。 |
+
+### 插件与集成
+
+官方集成统一维护在
+[EverMind plugins 仓库](https://github.com/EverMind-AI/plugins)。
+
+| 平台 | EverOS 集成 |
+|---|---|
+| [OpenClaw](https://docs.openclaw.ai) | [OpenClaw 插件](https://github.com/EverMind-AI/plugins/tree/main/openclaw)，自动管理召回、写入与会话记忆生命周期。 |
+| [Hermes Agent](https://github.com/NousResearch/hermes-agent) | [Hermes 插件](https://github.com/EverMind-AI/plugins/tree/main/hermes)，为 Hermes 会话提供持久记忆。 |
+| [DeepSeek Harness](https://github.com/deepseek-ai/DeepSeek-Harness) | [DSH 插件](https://github.com/EverMind-AI/plugins/tree/main/dsh)，让 DeepSeek Harness Agent 使用长期记忆。 |
+| [Dify](https://dify.ai) | [本地版](https://github.com/EverMind-AI/plugins/tree/main/dify)与[云端版](https://github.com/EverMind-AI/plugins/tree/main/dify_cloud)工具，在工作流和 Agent 中显式搜索与写入记忆。 |
+
+这些项目共同构成 EverMind 从研究到运行时的完整链路：将方法与评测转化为
+可复用的记忆基础设施、产品和 Agent 集成。
 
 <br>
 <div align="right">

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -688,7 +688,7 @@ EverMind 将记忆研究、可直接使用的产品与实际集成连接为一�
 <td>纵向评测 Agent 自进化、迁移效率、错误规避和 Skill 使用能力。</td>
 </tr>
 <tr>
-<th colspan="2">插件与集成</th>
+<th colspan="2"><a href="https://github.com/EverMind-AI/plugins">插件与集成</a></th>
 </tr>
 <tr>
 <td><strong><a href="https://docs.openclaw.ai">OpenClaw</a></strong></td>
@@ -705,10 +705,6 @@ EverMind 将记忆研究、可直接使用的产品与实际集成连接为一�
 <tr>
 <td><strong><a href="https://dify.ai">Dify</a></strong></td>
 <td><a href="https://github.com/EverMind-AI/plugins/tree/main/dify">本地版</a>与<a href="https://github.com/EverMind-AI/plugins/tree/main/dify_cloud">云端版</a>工具，在工作流和 Agent 中显式搜索与写入记忆。</td>
-</tr>
-<tr>
-<td><strong>集成中心</strong></td>
-<td>在 <a href="https://github.com/EverMind-AI/plugins">EverMind plugins 仓库</a>浏览全部官方集成。</td>
 </tr>
 </table>
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -657,7 +657,7 @@ EverMind 将记忆研究、可直接使用的产品与实际集成连接为一�
 <td>以记忆为核心的自进化 Agent Harness，具备主动性、上下文控制与 Skill 进化能力。</td>
 </tr>
 <tr>
-<td><strong><a href="https://github.com/EverMind-AI/EverMe">EverMe</a></strong></td>
+<td><strong><a href="https://github.com/EverMind-AI/EverMe">EverMe（CLI）</a></strong></td>
 <td>面向跨设备、跨 Agent 个人记忆的 CLI 与 Agent 插件套件。</td>
 </tr>
 <tr>


### PR DESCRIPTION
## Summary

- reorganize the EverMind Ecosystem section into Products, Research & Evaluation, and Integrations
- add current research projects and official OpenClaw, Hermes, DSH, and Dify integrations
- replace legacy integration entry points with the EverMind-AI/plugins repository
- keep the English and Simplified Chinese READMEs aligned

## Scope

This PR updates documentation only. The ecosystem diagram will be added separately.

## Validation

- git diff --check