### PR TITLE
docs: clarify EverOS former name

### DIFF
--- a/README.md
+++ b/README.md
@@ -468,7 +468,7 @@ Ruminer brings persistent memory to a browser agent so it can carry personal con
 
 #### EverMem Sync With EverOS
 
-One command to connect any AI coding CLI to EverMemOS long-term memory.
+One command to connect any AI coding CLI to EverOS (formerly called EverMemOS) for long-term memory.
 
 [Code](https://github.com/nanxingw/EverMem)
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -467,7 +467,7 @@ Ruminer 为 browser agent 带来持久记忆，让它能在不同网页任务之
 
 #### EverMem 与 EverOS 同步
 
-一条命令，把任意 AI coding CLI 连接到 EverMemOS 长期记忆。
+一条命令，把任意 AI coding CLI 连接到 EverOS（原名 EverMemOS），获得长期记忆。
 
 [代码](https://github.com/nanxingw/EverMem)
 

--- a/docs/use-cases.md
+++ b/docs/use-cases.md
@@ -147,7 +147,7 @@ Ruminer brings persistent memory to a browser agent so it can carry personal con
 
 #### EverMem Sync with EverOS
 
-One command to connect any AI coding CLI to EverOS long-term memory.
+One command to connect any AI coding CLI to EverOS (formerly called EverMemOS) for long-term memory.
 
 [Code](https://github.com/nanxingw/EverMem)
 

--- a/use-cases/README.md
+++ b/use-cases/README.md
@@ -145,7 +145,7 @@ Ruminer brings persistent memory to a browser agent so it can carry personal con
 
 #### EverMem Sync with EverOS
 
-One command to connect any AI coding CLI to EverMemOS long-term memory.
+One command to connect any AI coding CLI to EverOS (formerly called EverMemOS) for long-term memory.
 
 [Code](https://github.com/nanxingw/EverMem)
 


### PR DESCRIPTION
## Summary

- Update the public EverMem use-case copy to identify the current product as EverOS while retaining `formerly called EverMemOS` for historical context.
- Keep the English README, Chinese README, and both use-case documentation mirrors aligned without changing historical project URLs or compatibility identifiers.

## Area

- [ ] Architecture method
- [ ] Benchmark
- [x] Use case
- [x] Documentation
- [ ] Developer experience
- [ ] CI, build, or release

## Verification

```text
make docs-check
make ci
make check-cjk  # advisory; reports 10 existing repo-wide hits outside the changed locale mirror
make check-commits RANGE=origin/main..HEAD
make check-pr-title PR_TITLE='docs: clarify EverOS former name'
```

## Checklist

- [x] I kept the change scoped to the relevant area.
- [x] I am opening this from a separate branch, not pushing directly to `main`.
- [x] I updated docs, examples, or setup notes when behavior changed.
- [x] I added or updated tests when the change affects behavior.
- [x] I did not commit secrets, `.env` files, dependency folders, or generated output.
- [x] Active relative links in Markdown files resolve.

## Notes for Reviewers

Historical external repository URLs and demo compatibility identifiers still contain `EverMemOS` intentionally. Renaming those would break links or interfaces; this PR only updates the product name shown on the main repository's public documentation surfaces.

By submitting this pull request, I agree that my contribution is licensed under
the Apache License 2.0.
