### PR TITLE
docs: feature AIUI Sports Agents in use cases

### DIFF
--- a/README.md
+++ b/README.md
@@ -323,6 +323,17 @@ external demos or integrations you can study and adapt.
 <tr>
 <td width="50%" valign="top">
 
+[![AIUI Sports Agents for Smart Glasses](https://github.com/user-attachments/assets/7a8e6bca-6a12-4284-aa57-2f59fed7a6a2)](https://github.com/EasonZhu1997/AIUI-Sports-Agents)
+
+#### AIUI Sports Agents
+
+Sports agents for smart glasses, covering running, cycling, and indoor rowing. AISmartRun includes an optional memory-backend contract for post-run summaries; connecting it to EverOS requires a separately configured backend.
+
+[Code](https://github.com/EasonZhu1997/AIUI-Sports-Agents)
+
+</td>
+<td width="50%" valign="top">
+
 [![banner-gif](https://github.com/user-attachments/assets/840470d7-a838-4c05-8685-dd797d4e9cdf)](https://evermind.ai/usecase_reunite)
 
 #### Reunite - Find With EverOS
@@ -332,6 +343,9 @@ Parents describe what they remember. Children describe what they recall. Reunite
 [Learn more](https://evermind.ai/usecase_reunite)
 
 </td>
+</tr>
+
+<tr>
 <td width="50%" valign="top">
 
 [![banner-gif](https://github.com/user-attachments/assets/7282b38b-56bf-4356-aa7b-06a845e7683d)](https://github.com/tt-a1i/hive)
@@ -343,9 +357,6 @@ Browser-native hive-mind for CLI coding agents - Claude Code, Codex, Gemini, and
 [Code](https://github.com/tt-a1i/hive)
 
 </td>
-</tr>
-
-<tr>
 <td width="50%" valign="top">
 
 [![banner-gif](https://github.com/user-attachments/assets/867d9329-ce9a-496f-ab1e-15c77974e5fa)](https://github.com/tt-a1i/evermemos-mcp)
@@ -357,6 +368,9 @@ Universal long-term memory layer for AI coding assistants, powered by EverOS.
 [Code](https://github.com/tt-a1i/evermemos-mcp)
 
 </td>
+</tr>
+
+<tr>
 <td width="50%" valign="top">
 
 [![banner-gif](https://github.com/user-attachments/assets/a4f0fd86-1c81-4445-bebc-e51eb5e33b30)](https://github.com/yuansui123/AI-Data-Technician-EverMemOS)
@@ -368,9 +382,6 @@ An agentic AI system that learns from scientist interaction to inspect, analyze,
 [Code](https://github.com/yuansui123/AI-Data-Technician-EverMemOS)
 
 </td>
-</tr>
-
-<tr>
 <td width="50%" valign="top">
 
 ![banner-gif](https://github.com/user-attachments/assets/650b901b-c9ba-4001-bac7-626b009df830)
@@ -382,6 +393,15 @@ Connect to EverOS within Rokid Glasses enabling long-term memory for all of your
 Coming soon
 
 </td>
+</tr>
+
+<tr>
+<td colspan="2" align="right">
+<a href="#readme-top"><img src="https://img.shields.io/badge/-Back_to_top-gray?style=flat-square" alt="Back to top"></a>
+</td>
+</tr>
+
+<tr>
 <td width="50%" valign="top">
 
 ![banner-gif](https://github.com/user-attachments/assets/85b338b2-e48e-4a65-9f30-0bc6998df872)
@@ -393,15 +413,6 @@ Creative assistant with long-term memory, so your creative context stays availab
 Coming soon
 
 </td>
-</tr>
-
-<tr>
-<td colspan="2" align="right">
-<a href="#readme-top"><img src="https://img.shields.io/badge/-Back_to_top-gray?style=flat-square" alt="Back to top"></a>
-</td>
-</tr>
-
-<tr>
 <td width="50%" valign="top">
 
 [![banner-gif](https://github.com/user-attachments/assets/f30617a1-adc0-4271-bc0e-c3a0b28cb903)](https://github.com/xunyud/Earth-Online)
@@ -413,6 +424,9 @@ Earth Online is a memory-aware productivity game that turns everyday planning in
 [Code](https://github.com/xunyud/Earth-Online)
 
 </td>
+</tr>
+
+<tr>
 <td width="50%" valign="top">
 
 [![banner-gif](https://github.com/user-attachments/assets/57d8cda7-35a5-4561-b794-5520dffc917b)](https://github.com/golutra/golutra)
@@ -424,8 +438,6 @@ Golutra presents a multi-agent workforce for engineering teams, extending the ID
 [Code](https://github.com/golutra/golutra)
 
 </td>
-</tr>
-<tr>
 <td width="50%" valign="top">
 
 [![banner-gif](https://github.com/user-attachments/assets/75f19db5-30f6-4eed-9b1e-c9c6a0e6b7de)](https://github.com/Yangtze-Seventh/taste-verse)
@@ -437,6 +449,9 @@ Record, visualize, and explore your tasting journey through an immersive 3D star
 [Code](https://github.com/Yangtze-Seventh/taste-verse)
 
 </td>
+</tr>
+
+<tr>
 <td width="50%" valign="top">
 
 [![banner-gif](https://github.com/user-attachments/assets/93ac2a68-4f18-4fcb-8d87-80aeb00a9d7c)](https://github.com/kellyvv/OpenHer)
@@ -448,9 +463,6 @@ Build AI that feels. Open-source persona engine - personality emerges from neura
 [Code](https://github.com/kellyvv/OpenHer)
 
 </td>
-</tr>
-
-<tr>
 <td width="50%" valign="top">
 
 [![banner-gif](https://github.com/user-attachments/assets/550071c1-dc39-4964-9f67-ffdfad792345)](https://chromewebstore.google.com/detail/ruminer-browser-agent/lbccjohfpdpimbhpckljimgolndfmfif)
@@ -462,6 +474,15 @@ Ruminer brings persistent memory to a browser agent so it can carry personal con
 [Plugin](https://chromewebstore.google.com/detail/ruminer-browser-agent/lbccjohfpdpimbhpckljimgolndfmfif)
 
 </td>
+</tr>
+
+<tr>
+<td colspan="2" align="right">
+<a href="#readme-top"><img src="https://img.shields.io/badge/-Back_to_top-gray?style=flat-square" alt="Back to top"></a>
+</td>
+</tr>
+
+<tr>
 <td width="50%" valign="top">
 
 [![banner-gif](https://github.com/user-attachments/assets/c258a6c4-fe70-497a-98d1-3dade4a932f6)](https://github.com/nanxingw/EverMem)
@@ -473,15 +494,6 @@ One command to connect any AI coding CLI to EverOS (formerly called EverMemOS) f
 [Code](https://github.com/nanxingw/EverMem)
 
 </td>
-</tr>
-
-<tr>
-<td colspan="2" align="right">
-<a href="#readme-top"><img src="https://img.shields.io/badge/-Back_to_top-gray?style=flat-square" alt="Back to top"></a>
-</td>
-</tr>
-
-<tr>
 <td width="50%" valign="top">
 
 [![banner-gif](https://github.com/user-attachments/assets/39274473-ceb3-48fb-a031-e22230decbe2)](https://github.com/mco-org/mco)
@@ -493,6 +505,9 @@ MCO equips your primary agent with an agent team that can work together to solve
 [Code](https://github.com/mco-org/mco)
 
 </td>
+</tr>
+
+<tr>
 <td width="50%" valign="top">
 
 [![banner-gif](https://github.com/user-attachments/assets/314c9126-8e08-4688-bbbb-8555ad58cf67)](https://github.com/onenewborn/StudyBuddy-public)
@@ -504,9 +519,6 @@ Study proactively with an agent that has self-evolving memory.
 [Code](https://github.com/onenewborn/StudyBuddy-public)
 
 </td>
-</tr>
-
-<tr>
 <td width="50%" valign="top">
 
 [![banner-gif](https://github.com/user-attachments/assets/21da76aa-9a8b-48e0-9134-42429d7390e7)](https://github.com/TonyLiangDesign/MemoCare)
@@ -518,6 +530,9 @@ Empowering individuals with advanced memory support and daily assistance.
 [Code](https://github.com/TonyLiangDesign/MemoCare)
 
 </td>
+</tr>
+
+<tr>
 <td width="50%" valign="top">
 
 [![banner-gif](https://github.com/user-attachments/assets/e2428df3-ea11-4e88-8f9c-dad437dd8998)](https://github.com/AlexL1024/NeuralConnect)
@@ -529,9 +544,6 @@ An iOS sci-fi mystery game where players explore and uncover the truth.
 [Code](https://github.com/AlexL1024/NeuralConnect)
 
 </td>
-</tr>
-
-<tr>
 <td width="50%" valign="top">
 
 [![banner-gif](https://github.com/user-attachments/assets/e6eaf308-a874-483f-8874-6934bf95a78f)](https://github.com/elontusk5219-prog/Mobi)
@@ -543,6 +555,15 @@ An iOS app where users create, nurture, and live with a personalized AI companio
 [Code](https://github.com/elontusk5219-prog/Mobi)
 
 </td>
+</tr>
+
+<tr>
+<td colspan="2" align="right">
+<a href="#readme-top"><img src="https://img.shields.io/badge/-Back_to_top-gray?style=flat-square" alt="Back to top"></a>
+</td>
+</tr>
+
+<tr>
 <td width="50%" valign="top">
 
 [![banner-gif](https://github.com/user-attachments/assets/9aabcaa9-f97a-49d2-9109-0b5bb696ed41)](https://github.com/JaMesLiMers/EvermemCompetition-Spiro)
@@ -554,14 +575,6 @@ A context-native AI wearable that listens to everyday life and converts conversa
 [Code](https://github.com/JaMesLiMers/EvermemCompetition-Spiro)
 
 </td>
-</tr>
-
-<tr>
-<td colspan="2" align="right">
-<a href="#readme-top"><img src="https://img.shields.io/badge/-Back_to_top-gray?style=flat-square" alt="Back to top"></a>
-</td>
-</tr>
-<tr>
 <td width="50%" valign="top">
 
 [![banner-gif](https://github.com/user-attachments/assets/df9677ec-386f-4c56-a428-08bca25c54dc)](docs/migration-to-1.0.0.md)
@@ -573,6 +586,9 @@ Archived pre-1.0.0 plugin reference. New integrations should use the current Eve
 [Learn more](docs/migration-to-1.0.0.md)
 
 </td>
+</tr>
+
+<tr>
 <td width="50%" valign="top">
 
 [![banner-gif](https://github.com/user-attachments/assets/3a2357a1-c0c3-464a-8979-0d1cdfc9b0d4)](https://github.com/TEN-framework/ten-framework/tree/04cb80601374fa9e35b4e544b2dbd23286ca7763/ai_agents/agents/examples/voice-assistant-with-EverMemOS)
@@ -584,8 +600,6 @@ Add long-term memory to a real-time Live2D character, powered by [TEN Framework]
 [Code](https://github.com/TEN-framework/ten-framework/tree/04cb80601374fa9e35b4e544b2dbd23286ca7763/ai_agents/agents/examples/voice-assistant-with-EverMemOS)
 
 </td>
-</tr>
-<tr>
 <td width="50%" valign="top">
 
 [![banner-gif](https://github.com/user-attachments/assets/c36bdc04-97d3-4fe9-97d9-4b93b475595a)](https://screenshot-analysis-vercel.vercel.app/)
@@ -597,6 +611,9 @@ Run screenshot-based analysis with computer-use and store the results in memory.
 [Live Demo](https://screenshot-analysis-vercel.vercel.app/)
 
 </td>
+</tr>
+
+<tr>
 <td width="50%" valign="top">
 
 [![banner-gif](https://github.com/user-attachments/assets/54a7cf8f-62c4-4fbc-9d50-b214d034e051)](use-cases/game-of-throne-demo)
@@ -608,8 +625,6 @@ A demonstration of AI memory infrastructure through an interactive Q&A experienc
 [Code](use-cases/game-of-throne-demo)
 
 </td>
-</tr>
-<tr>
 <td width="50%" valign="top">
 
 [![banner-gif](https://github.com/user-attachments/assets/af37c1f6-7ba5-430c-b99d-2a7e7eac618f)](use-cases/claude-code-plugin)
@@ -621,6 +636,9 @@ Persistent memory for Claude Code. Automatically saves and recalls context from 
 [Code](use-cases/claude-code-plugin)
 
 </td>
+</tr>
+
+<tr>
 <td width="50%" valign="top">
 
 [![banner-gif](https://github.com/user-attachments/assets/d521d28c-0ccd-44ff-aecc-828245e2f973)](https://main.d2j21qxnymu6wl.amplifyapp.com/graph.html)
@@ -632,6 +650,7 @@ Explore stored entities and relationships in a graph interface. Frontend demo; b
 [Live Demo](https://main.d2j21qxnymu6wl.amplifyapp.com/graph.html)
 
 </td>
+<td width="50%" valign="top"></td>
 </tr>
 </table>
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -322,6 +322,17 @@ make test
 <tr>
 <td width="50%" valign="top">
 
+[![AIUI Sports Agents for Smart Glasses](https://github.com/user-attachments/assets/7a8e6bca-6a12-4284-aa57-2f59fed7a6a2)](https://github.com/EasonZhu1997/AIUI-Sports-Agents)
+
+#### AIUI Sports Agents
+
+面向智能眼镜的运动 agents，覆盖跑步、骑行和室内划船。AISmartRun 提供用于跑后总结的可选记忆后端接口；接入 EverOS 需要单独配置后端服务。
+
+[代码](https://github.com/EasonZhu1997/AIUI-Sports-Agents)
+
+</td>
+<td width="50%" valign="top">
+
 [![banner-gif](https://github.com/user-attachments/assets/840470d7-a838-4c05-8685-dd797d4e9cdf)](https://evermind.ai/usecase_reunite)
 
 #### Reunite - 用 EverOS 找回连接
@@ -331,6 +342,9 @@ make test
 [了解更多](https://evermind.ai/usecase_reunite)
 
 </td>
+</tr>
+
+<tr>
 <td width="50%" valign="top">
 
 [![banner-gif](https://github.com/user-attachments/assets/7282b38b-56bf-4356-aa7b-06a845e7683d)](https://github.com/tt-a1i/hive)
@@ -342,9 +356,6 @@ make test
 [代码](https://github.com/tt-a1i/hive)
 
 </td>
-</tr>
-
-<tr>
 <td width="50%" valign="top">
 
 [![banner-gif](https://github.com/user-attachments/assets/867d9329-ce9a-496f-ab1e-15c77974e5fa)](https://github.com/tt-a1i/evermemos-mcp)
@@ -356,6 +367,9 @@ make test
 [代码](https://github.com/tt-a1i/evermemos-mcp)
 
 </td>
+</tr>
+
+<tr>
 <td width="50%" valign="top">
 
 [![banner-gif](https://github.com/user-attachments/assets/a4f0fd86-1c81-4445-bebc-e51eb5e33b30)](https://github.com/yuansui123/AI-Data-Technician-EverMemOS)
@@ -367,9 +381,6 @@ make test
 [代码](https://github.com/yuansui123/AI-Data-Technician-EverMemOS)
 
 </td>
-</tr>
-
-<tr>
 <td width="50%" valign="top">
 
 ![banner-gif](https://github.com/user-attachments/assets/650b901b-c9ba-4001-bac7-626b009df830)
@@ -381,6 +392,15 @@ make test
 即将推出
 
 </td>
+</tr>
+
+<tr>
+<td colspan="2" align="right">
+<a href="#readme-top"><img src="https://img.shields.io/badge/-Back_to_top-gray?style=flat-square" alt="Back to top"></a>
+</td>
+</tr>
+
+<tr>
 <td width="50%" valign="top">
 
 ![banner-gif](https://github.com/user-attachments/assets/85b338b2-e48e-4a65-9f30-0bc6998df872)
@@ -392,15 +412,6 @@ make test
 即将推出
 
 </td>
-</tr>
-
-<tr>
-<td colspan="2" align="right">
-<a href="#readme-top"><img src="https://img.shields.io/badge/-Back_to_top-gray?style=flat-square" alt="Back to top"></a>
-</td>
-</tr>
-
-<tr>
 <td width="50%" valign="top">
 
 [![banner-gif](https://github.com/user-attachments/assets/f30617a1-adc0-4271-bc0e-c3a0b28cb903)](https://github.com/xunyud/Earth-Online)
@@ -412,6 +423,9 @@ Earth Online 是一款 memory-aware productivity game，把日常计划变成一
 [代码](https://github.com/xunyud/Earth-Online)
 
 </td>
+</tr>
+
+<tr>
 <td width="50%" valign="top">
 
 [![banner-gif](https://github.com/user-attachments/assets/57d8cda7-35a5-4561-b794-5520dffc917b)](https://github.com/golutra/golutra)
@@ -423,8 +437,6 @@ Golutra 为工程团队提供 multi-agent workforce，把 IDE 从单一 assistan
 [代码](https://github.com/golutra/golutra)
 
 </td>
-</tr>
-<tr>
 <td width="50%" valign="top">
 
 [![banner-gif](https://github.com/user-attachments/assets/75f19db5-30f6-4eed-9b1e-c9c6a0e6b7de)](https://github.com/Yangtze-Seventh/taste-verse)
@@ -436,6 +448,9 @@ Golutra 为工程团队提供 multi-agent workforce，把 IDE 从单一 assistan
 [代码](https://github.com/Yangtze-Seventh/taste-verse)
 
 </td>
+</tr>
+
+<tr>
 <td width="50%" valign="top">
 
 [![banner-gif](https://github.com/user-attachments/assets/93ac2a68-4f18-4fcb-8d87-80aeb00a9d7c)](https://github.com/kellyvv/OpenHer)
@@ -447,9 +462,6 @@ Golutra 为工程团队提供 multi-agent workforce，把 IDE 从单一 assistan
 [代码](https://github.com/kellyvv/OpenHer)
 
 </td>
-</tr>
-
-<tr>
 <td width="50%" valign="top">
 
 [![banner-gif](https://github.com/user-attachments/assets/550071c1-dc39-4964-9f67-ffdfad792345)](https://chromewebstore.google.com/detail/ruminer-browser-agent/lbccjohfpdpimbhpckljimgolndfmfif)
@@ -461,6 +473,15 @@ Ruminer 为 browser agent 带来持久记忆，让它能在不同网页任务之
 [插件](https://chromewebstore.google.com/detail/ruminer-browser-agent/lbccjohfpdpimbhpckljimgolndfmfif)
 
 </td>
+</tr>
+
+<tr>
+<td colspan="2" align="right">
+<a href="#readme-top"><img src="https://img.shields.io/badge/-Back_to_top-gray?style=flat-square" alt="Back to top"></a>
+</td>
+</tr>
+
+<tr>
 <td width="50%" valign="top">
 
 [![banner-gif](https://github.com/user-attachments/assets/c258a6c4-fe70-497a-98d1-3dade4a932f6)](https://github.com/nanxingw/EverMem)
@@ -472,15 +493,6 @@ Ruminer 为 browser agent 带来持久记忆，让它能在不同网页任务之
 [代码](https://github.com/nanxingw/EverMem)
 
 </td>
-</tr>
-
-<tr>
-<td colspan="2" align="right">
-<a href="#readme-top"><img src="https://img.shields.io/badge/-Back_to_top-gray?style=flat-square" alt="Back to top"></a>
-</td>
-</tr>
-
-<tr>
 <td width="50%" valign="top">
 
 [![banner-gif](https://github.com/user-attachments/assets/39274473-ceb3-48fb-a031-e22230decbe2)](https://github.com/mco-org/mco)
@@ -492,6 +504,9 @@ MCO 为你的主 Agent 配备一个 agent team，让它们可以一起处理复�
 [代码](https://github.com/mco-org/mco)
 
 </td>
+</tr>
+
+<tr>
 <td width="50%" valign="top">
 
 [![banner-gif](https://github.com/user-attachments/assets/314c9126-8e08-4688-bbbb-8555ad58cf67)](https://github.com/onenewborn/StudyBuddy-public)
@@ -503,9 +518,6 @@ MCO 为你的主 Agent 配备一个 agent team，让它们可以一起处理复�
 [代码](https://github.com/onenewborn/StudyBuddy-public)
 
 </td>
-</tr>
-
-<tr>
 <td width="50%" valign="top">
 
 [![banner-gif](https://github.com/user-attachments/assets/21da76aa-9a8b-48e0-9134-42429d7390e7)](https://github.com/TonyLiangDesign/MemoCare)
@@ -517,6 +529,9 @@ MCO 为你的主 Agent 配备一个 agent team，让它们可以一起处理复�
 [代码](https://github.com/TonyLiangDesign/MemoCare)
 
 </td>
+</tr>
+
+<tr>
 <td width="50%" valign="top">
 
 [![banner-gif](https://github.com/user-attachments/assets/e2428df3-ea11-4e88-8f9c-dad437dd8998)](https://github.com/AlexL1024/NeuralConnect)
@@ -528,9 +543,6 @@ MCO 为你的主 Agent 配备一个 agent team，让它们可以一起处理复�
 [代码](https://github.com/AlexL1024/NeuralConnect)
 
 </td>
-</tr>
-
-<tr>
 <td width="50%" valign="top">
 
 [![banner-gif](https://github.com/user-attachments/assets/e6eaf308-a874-483f-8874-6934bf95a78f)](https://github.com/elontusk5219-prog/Mobi)
@@ -542,6 +554,15 @@ MCO 为你的主 Agent 配备一个 agent team，让它们可以一起处理复�
 [代码](https://github.com/elontusk5219-prog/Mobi)
 
 </td>
+</tr>
+
+<tr>
+<td colspan="2" align="right">
+<a href="#readme-top"><img src="https://img.shields.io/badge/-Back_to_top-gray?style=flat-square" alt="Back to top"></a>
+</td>
+</tr>
+
+<tr>
 <td width="50%" valign="top">
 
 [![banner-gif](https://github.com/user-attachments/assets/9aabcaa9-f97a-49d2-9109-0b5bb696ed41)](https://github.com/JaMesLiMers/EvermemCompetition-Spiro)
@@ -553,14 +574,6 @@ MCO 为你的主 Agent 配备一个 agent team，让它们可以一起处理复�
 [代码](https://github.com/JaMesLiMers/EvermemCompetition-Spiro)
 
 </td>
-</tr>
-
-<tr>
-<td colspan="2" align="right">
-<a href="#readme-top"><img src="https://img.shields.io/badge/-Back_to_top-gray?style=flat-square" alt="Back to top"></a>
-</td>
-</tr>
-<tr>
 <td width="50%" valign="top">
 
 [![banner-gif](https://github.com/user-attachments/assets/df9677ec-386f-4c56-a428-08bca25c54dc)](docs/migration-to-1.0.0.md)
@@ -572,6 +585,9 @@ MCO 为你的主 Agent 配备一个 agent team，让它们可以一起处理复�
 [了解更多](docs/migration-to-1.0.0.md)
 
 </td>
+</tr>
+
+<tr>
 <td width="50%" valign="top">
 
 [![banner-gif](https://github.com/user-attachments/assets/3a2357a1-c0c3-464a-8979-0d1cdfc9b0d4)](https://github.com/TEN-framework/ten-framework/tree/04cb80601374fa9e35b4e544b2dbd23286ca7763/ai_agents/agents/examples/voice-assistant-with-EverMemOS)
@@ -583,8 +599,6 @@ MCO 为你的主 Agent 配备一个 agent team，让它们可以一起处理复�
 [代码](https://github.com/TEN-framework/ten-framework/tree/04cb80601374fa9e35b4e544b2dbd23286ca7763/ai_agents/agents/examples/voice-assistant-with-EverMemOS)
 
 </td>
-</tr>
-<tr>
 <td width="50%" valign="top">
 
 [![banner-gif](https://github.com/user-attachments/assets/c36bdc04-97d3-4fe9-97d9-4b93b475595a)](https://screenshot-analysis-vercel.vercel.app/)
@@ -596,6 +610,9 @@ MCO 为你的主 Agent 配备一个 agent team，让它们可以一起处理复�
 [在线演示](https://screenshot-analysis-vercel.vercel.app/)
 
 </td>
+</tr>
+
+<tr>
 <td width="50%" valign="top">
 
 [![banner-gif](https://github.com/user-attachments/assets/54a7cf8f-62c4-4fbc-9d50-b214d034e051)](use-cases/game-of-throne-demo)
@@ -607,8 +624,6 @@ MCO 为你的主 Agent 配备一个 agent team，让它们可以一起处理复�
 [代码](use-cases/game-of-throne-demo)
 
 </td>
-</tr>
-<tr>
 <td width="50%" valign="top">
 
 [![banner-gif](https://github.com/user-attachments/assets/af37c1f6-7ba5-430c-b99d-2a7e7eac618f)](use-cases/claude-code-plugin)
@@ -620,6 +635,9 @@ Claude Code 的持久记忆插件。自动保存并回忆过去 coding sessions 
 [代码](use-cases/claude-code-plugin)
 
 </td>
+</tr>
+
+<tr>
 <td width="50%" valign="top">
 
 [![banner-gif](https://github.com/user-attachments/assets/d521d28c-0ccd-44ff-aecc-828245e2f973)](https://main.d2j21qxnymu6wl.amplifyapp.com/graph.html)
@@ -631,6 +649,7 @@ Claude Code 的持久记忆插件。自动保存并回忆过去 coding sessions 
 [在线演示](https://main.d2j21qxnymu6wl.amplifyapp.com/graph.html)
 
 </td>
+<td width="50%" valign="top"></td>
 </tr>
 </table>
 

--- a/docs/use-cases.md
+++ b/docs/use-cases.md
@@ -8,6 +8,17 @@ external demos or integrations you can study and adapt.
 <tr>
 <td width="50%" valign="top">
 
+[![AIUI Sports Agents for Smart Glasses](https://github.com/user-attachments/assets/7a8e6bca-6a12-4284-aa57-2f59fed7a6a2)](https://github.com/EasonZhu1997/AIUI-Sports-Agents)
+
+#### AIUI Sports Agents
+
+Sports agents for smart glasses, covering running, cycling, and indoor rowing. AISmartRun includes an optional memory-backend contract for post-run summaries; connecting it to EverOS requires a separately configured backend.
+
+[Code](https://github.com/EasonZhu1997/AIUI-Sports-Agents)
+
+</td>
+<td width="50%" valign="top">
+
 [![banner-gif](https://github.com/user-attachments/assets/840470d7-a838-4c05-8685-dd797d4e9cdf)](https://evermind.ai/usecase_reunite)
 
 #### Reunite - Find with EverOS
@@ -17,6 +28,9 @@ Parents describe what they remember. Children describe what they recall. Reunite
 [Learn more](https://evermind.ai/usecase_reunite)
 
 </td>
+</tr>
+
+<tr>
 <td width="50%" valign="top">
 
 [![banner-gif](https://github.com/user-attachments/assets/7282b38b-56bf-4356-aa7b-06a845e7683d)](https://github.com/tt-a1i/hive)
@@ -28,9 +42,6 @@ Browser-native hive-mind for CLI coding agents - Claude Code, Codex, Gemini, and
 [Code](https://github.com/tt-a1i/hive)
 
 </td>
-</tr>
-
-<tr>
 <td width="50%" valign="top">
 
 [![banner-gif](https://github.com/user-attachments/assets/867d9329-ce9a-496f-ab1e-15c77974e5fa)](https://github.com/tt-a1i/evermemos-mcp)
@@ -42,6 +53,9 @@ Universal long-term memory layer for AI coding assistants, powered by EverOS.
 [Code](https://github.com/tt-a1i/evermemos-mcp)
 
 </td>
+</tr>
+
+<tr>
 <td width="50%" valign="top">
 
 [![banner-gif](https://github.com/user-attachments/assets/a4f0fd86-1c81-4445-bebc-e51eb5e33b30)](https://github.com/yuansui123/AI-Data-Technician-EverMemOS)
@@ -53,9 +67,6 @@ An agentic AI system that learns from scientist interaction to inspect, analyze,
 [Code](https://github.com/yuansui123/AI-Data-Technician-EverMemOS)
 
 </td>
-</tr>
-
-<tr>
 <td width="50%" valign="top">
 
 ![banner-gif](https://github.com/user-attachments/assets/650b901b-c9ba-4001-bac7-626b009df830)
@@ -67,6 +78,9 @@ Connect to EverOS within Rokid Glasses enabling long-term memory for all of your
 Coming soon
 
 </td>
+</tr>
+
+<tr>
 <td width="50%" valign="top">
 
 ![banner-gif](https://github.com/user-attachments/assets/85b338b2-e48e-4a65-9f30-0bc6998df872)
@@ -78,9 +92,6 @@ Creative assistant with long-term memory, so your creative context stays availab
 Coming soon
 
 </td>
-</tr>
-
-<tr>
 <td width="50%" valign="top">
 
 [![banner-gif](https://github.com/user-attachments/assets/f30617a1-adc0-4271-bc0e-c3a0b28cb903)](https://github.com/xunyud/Earth-Online)
@@ -92,6 +103,9 @@ Earth Online is a memory-aware productivity game that turns everyday planning in
 [Code](https://github.com/xunyud/Earth-Online)
 
 </td>
+</tr>
+
+<tr>
 <td width="50%" valign="top">
 
 [![banner-gif](https://github.com/user-attachments/assets/57d8cda7-35a5-4561-b794-5520dffc917b)](https://github.com/golutra/golutra)
@@ -103,8 +117,6 @@ Golutra presents a multi-agent workforce for engineering teams, extending the ID
 [Code](https://github.com/golutra/golutra)
 
 </td>
-</tr>
-<tr>
 <td width="50%" valign="top">
 
 [![banner-gif](https://github.com/user-attachments/assets/75f19db5-30f6-4eed-9b1e-c9c6a0e6b7de)](https://github.com/Yangtze-Seventh/taste-verse)
@@ -116,6 +128,9 @@ Record, visualize, and explore your tasting journey through an immersive 3D star
 [Code](https://github.com/Yangtze-Seventh/taste-verse)
 
 </td>
+</tr>
+
+<tr>
 <td width="50%" valign="top">
 
 [![banner-gif](https://github.com/user-attachments/assets/93ac2a68-4f18-4fcb-8d87-80aeb00a9d7c)](https://github.com/kellyvv/OpenHer)
@@ -127,9 +142,6 @@ Build AI that feels. Open-source persona engine - personality emerges from neura
 [Code](https://github.com/kellyvv/OpenHer)
 
 </td>
-</tr>
-
-<tr>
 <td width="50%" valign="top">
 
 [![banner-gif](https://github.com/user-attachments/assets/550071c1-dc39-4964-9f67-ffdfad792345)](https://chromewebstore.google.com/detail/ruminer-browser-agent/lbccjohfpdpimbhpckljimgolndfmfif)
@@ -141,6 +153,9 @@ Ruminer brings persistent memory to a browser agent so it can carry personal con
 [Plugin](https://chromewebstore.google.com/detail/ruminer-browser-agent/lbccjohfpdpimbhpckljimgolndfmfif)
 
 </td>
+</tr>
+
+<tr>
 <td width="50%" valign="top">
 
 [![banner-gif](https://github.com/user-attachments/assets/c258a6c4-fe70-497a-98d1-3dade4a932f6)](https://github.com/nanxingw/EverMem)
@@ -152,9 +167,6 @@ One command to connect any AI coding CLI to EverOS (formerly called EverMemOS) f
 [Code](https://github.com/nanxingw/EverMem)
 
 </td>
-</tr>
-
-<tr>
 <td width="50%" valign="top">
 
 [![banner-gif](https://github.com/user-attachments/assets/39274473-ceb3-48fb-a031-e22230decbe2)](https://github.com/mco-org/mco)
@@ -166,6 +178,9 @@ MCO equips your primary agent with an agent team that can work together to solve
 [Code](https://github.com/mco-org/mco)
 
 </td>
+</tr>
+
+<tr>
 <td width="50%" valign="top">
 
 [![banner-gif](https://github.com/user-attachments/assets/314c9126-8e08-4688-bbbb-8555ad58cf67)](https://github.com/onenewborn/StudyBuddy-public)
@@ -177,9 +192,6 @@ Study proactively with an agent that has self-evolving memory.
 [Code](https://github.com/onenewborn/StudyBuddy-public)
 
 </td>
-</tr>
-
-<tr>
 <td width="50%" valign="top">
 
 [![banner-gif](https://github.com/user-attachments/assets/21da76aa-9a8b-48e0-9134-42429d7390e7)](https://github.com/TonyLiangDesign/MemoCare)
@@ -191,6 +203,9 @@ Empowering individuals with advanced memory support and daily assistance.
 [Code](https://github.com/TonyLiangDesign/MemoCare)
 
 </td>
+</tr>
+
+<tr>
 <td width="50%" valign="top">
 
 [![banner-gif](https://github.com/user-attachments/assets/e2428df3-ea11-4e88-8f9c-dad437dd8998)](https://github.com/AlexL1024/NeuralConnect)
@@ -202,9 +217,6 @@ An iOS sci-fi mystery game where players explore and uncover the truth.
 [Code](https://github.com/AlexL1024/NeuralConnect)
 
 </td>
-</tr>
-
-<tr>
 <td width="50%" valign="top">
 
 [![banner-gif](https://github.com/user-attachments/assets/e6eaf308-a874-483f-8874-6934bf95a78f)](https://github.com/elontusk5219-prog/Mobi)
@@ -216,6 +228,9 @@ An iOS app where users create, nurture, and live with a personalized AI companio
 [Code](https://github.com/elontusk5219-prog/Mobi)
 
 </td>
+</tr>
+
+<tr>
 <td width="50%" valign="top">
 
 [![banner-gif](https://github.com/user-attachments/assets/9aabcaa9-f97a-49d2-9109-0b5bb696ed41)](https://github.com/JaMesLiMers/EvermemCompetition-Spiro)
@@ -227,8 +242,6 @@ A context-native AI wearable that listens to everyday life and converts conversa
 [Code](https://github.com/JaMesLiMers/EvermemCompetition-Spiro)
 
 </td>
-</tr>
-<tr>
 <td width="50%" valign="top">
 
 [![banner-gif](https://github.com/user-attachments/assets/df9677ec-386f-4c56-a428-08bca25c54dc)](migration-to-1.0.0.md)
@@ -240,6 +253,9 @@ Archived pre-1.0.0 plugin reference. New integrations should use the current Eve
 [Learn more](migration-to-1.0.0.md)
 
 </td>
+</tr>
+
+<tr>
 <td width="50%" valign="top">
 
 [![banner-gif](https://github.com/user-attachments/assets/3a2357a1-c0c3-464a-8979-0d1cdfc9b0d4)](https://github.com/TEN-framework/ten-framework/tree/04cb80601374fa9e35b4e544b2dbd23286ca7763/ai_agents/agents/examples/voice-assistant-with-EverMemOS)
@@ -251,8 +267,6 @@ Add long-term memory to a real-time Live2D character, powered by [TEN Framework]
 [Code](https://github.com/TEN-framework/ten-framework/tree/04cb80601374fa9e35b4e544b2dbd23286ca7763/ai_agents/agents/examples/voice-assistant-with-EverMemOS)
 
 </td>
-</tr>
-<tr>
 <td width="50%" valign="top">
 
 [![banner-gif](https://github.com/user-attachments/assets/c36bdc04-97d3-4fe9-97d9-4b93b475595a)](https://screenshot-analysis-vercel.vercel.app/)
@@ -264,6 +278,9 @@ Run screenshot-based analysis with computer-use and store the results in memory.
 [Live Demo](https://screenshot-analysis-vercel.vercel.app/)
 
 </td>
+</tr>
+
+<tr>
 <td width="50%" valign="top">
 
 [![banner-gif](https://github.com/user-attachments/assets/54a7cf8f-62c4-4fbc-9d50-b214d034e051)](../use-cases/game-of-throne-demo)
@@ -275,8 +292,6 @@ A demonstration of AI memory infrastructure through an interactive Q&A experienc
 [Code](../use-cases/game-of-throne-demo)
 
 </td>
-</tr>
-<tr>
 <td width="50%" valign="top">
 
 [![banner-gif](https://github.com/user-attachments/assets/af37c1f6-7ba5-430c-b99d-2a7e7eac618f)](../use-cases/claude-code-plugin)
@@ -288,6 +303,9 @@ Persistent memory for Claude Code. Automatically saves and recalls context from 
 [Code](../use-cases/claude-code-plugin)
 
 </td>
+</tr>
+
+<tr>
 <td width="50%" valign="top">
 
 [![banner-gif](https://github.com/user-attachments/assets/d521d28c-0ccd-44ff-aecc-828245e2f973)](https://main.d2j21qxnymu6wl.amplifyapp.com/graph.html)
@@ -299,6 +317,7 @@ Explore stored entities and relationships in a graph interface. Frontend demo; b
 [Live Demo](https://main.d2j21qxnymu6wl.amplifyapp.com/graph.html)
 
 </td>
+<td width="50%" valign="top"></td>
 </tr>
 </table>
 

--- a/use-cases/README.md
+++ b/use-cases/README.md
@@ -6,6 +6,17 @@ Use cases show what persistent memory makes possible in real products and workfl
 <tr>
 <td width="50%" valign="top">
 
+[![AIUI Sports Agents for Smart Glasses](https://github.com/user-attachments/assets/7a8e6bca-6a12-4284-aa57-2f59fed7a6a2)](https://github.com/EasonZhu1997/AIUI-Sports-Agents)
+
+#### AIUI Sports Agents
+
+Sports agents for smart glasses, covering running, cycling, and indoor rowing. AISmartRun includes an optional memory-backend contract for post-run summaries; connecting it to EverOS requires a separately configured backend.
+
+[Code](https://github.com/EasonZhu1997/AIUI-Sports-Agents)
+
+</td>
+<td width="50%" valign="top">
+
 [![banner-gif](https://github.com/user-attachments/assets/840470d7-a838-4c05-8685-dd797d4e9cdf)](https://evermind.ai/usecase_reunite)
 
 #### Reunite - Find with EverOS
@@ -15,6 +26,9 @@ Parents describe what they remember. Children describe what they recall. Reunite
 [Learn more](https://evermind.ai/usecase_reunite)
 
 </td>
+</tr>
+
+<tr>
 <td width="50%" valign="top">
 
 [![banner-gif](https://github.com/user-attachments/assets/7282b38b-56bf-4356-aa7b-06a845e7683d)](https://github.com/tt-a1i/hive)
@@ -26,9 +40,6 @@ Browser-native hive-mind for CLI coding agents — Claude Code, Codex, Gemini, a
 [Code](https://github.com/tt-a1i/hive)
 
 </td>
-</tr>
-
-<tr>
 <td width="50%" valign="top">
 
 [![banner-gif](https://github.com/user-attachments/assets/867d9329-ce9a-496f-ab1e-15c77974e5fa)](https://github.com/tt-a1i/evermemos-mcp)
@@ -40,6 +51,9 @@ Universal long-term memory layer for AI coding assistants, powered by EverOS.
 [Code](https://github.com/tt-a1i/evermemos-mcp)
 
 </td>
+</tr>
+
+<tr>
 <td width="50%" valign="top">
 
 [![banner-gif](https://github.com/user-attachments/assets/a4f0fd86-1c81-4445-bebc-e51eb5e33b30)](https://github.com/yuansui123/AI-Data-Technician-EverMemOS)
@@ -51,9 +65,6 @@ An agentic AI system that learns from scientist interaction to inspect, analyze,
 [Code](https://github.com/yuansui123/AI-Data-Technician-EverMemOS)
 
 </td>
-</tr>
-
-<tr>
 <td width="50%" valign="top">
 
 ![banner-gif](https://github.com/user-attachments/assets/650b901b-c9ba-4001-bac7-626b009df830)
@@ -65,6 +76,9 @@ Connect to EverOS within Rokid Glasses enabling long-term memory for all of your
 Coming soon
 
 </td>
+</tr>
+
+<tr>
 <td width="50%" valign="top">
 
 ![banner-gif](https://github.com/user-attachments/assets/85b338b2-e48e-4a65-9f30-0bc6998df872)
@@ -76,9 +90,6 @@ Creative assistant with long-term memory, never forget your crativites anymore.
 Coming soon
 
 </td>
-</tr>
-
-<tr>
 <td width="50%" valign="top">
 
 [![banner-gif](https://github.com/user-attachments/assets/f30617a1-adc0-4271-bc0e-c3a0b28cb903)](https://github.com/xunyud/Earth-Online)
@@ -90,6 +101,9 @@ Earth Online is a memory-aware productivity game that turns everyday planning in
 [Code](https://github.com/xunyud/Earth-Online)
 
 </td>
+</tr>
+
+<tr>
 <td width="50%" valign="top">
 
 [![banner-gif](https://github.com/user-attachments/assets/57d8cda7-35a5-4561-b794-5520dffc917b)](https://github.com/golutra/golutra)
@@ -101,8 +115,6 @@ Golutra presents a multi-agent workforce for engineering teams, extending the ID
 [Code](https://github.com/golutra/golutra)
 
 </td>
-</tr>
-<tr>
 <td width="50%" valign="top">
 
 [![banner-gif](https://github.com/user-attachments/assets/75f19db5-30f6-4eed-9b1e-c9c6a0e6b7de)](https://github.com/Yangtze-Seventh/taste-verse)
@@ -114,6 +126,9 @@ Record, visualize, and explore your tasting journey through an immersive 3D star
 [Code](https://github.com/Yangtze-Seventh/taste-verse)
 
 </td>
+</tr>
+
+<tr>
 <td width="50%" valign="top">
 
 [![banner-gif](https://github.com/user-attachments/assets/93ac2a68-4f18-4fcb-8d87-80aeb00a9d7c)](https://github.com/kellyvv/OpenHer)
@@ -125,9 +140,6 @@ Build AI that feels. Open-source persona engine — personality emerges from neu
 [Code](https://github.com/kellyvv/OpenHer)
 
 </td>
-</tr>
-
-<tr>
 <td width="50%" valign="top">
 
 [![banner-gif](https://github.com/user-attachments/assets/550071c1-dc39-4964-9f67-ffdfad792345)](https://chromewebstore.google.com/detail/ruminer-browser-agent/lbccjohfpdpimbhpckljimgolndfmfif)
@@ -139,6 +151,9 @@ Ruminer brings persistent memory to a browser agent so it can carry personal con
 [Plugin](https://chromewebstore.google.com/detail/ruminer-browser-agent/lbccjohfpdpimbhpckljimgolndfmfif)
 
 </td>
+</tr>
+
+<tr>
 <td width="50%" valign="top">
 
 [![banner-gif](https://github.com/user-attachments/assets/c258a6c4-fe70-497a-98d1-3dade4a932f6)](https://github.com/nanxingw/EverMem)
@@ -150,9 +165,6 @@ One command to connect any AI coding CLI to EverOS (formerly called EverMemOS) f
 [Code](https://github.com/nanxingw/EverMem)
 
 </td>
-</tr>
-
-<tr>
 <td width="50%" valign="top">
 
 [![banner-gif](https://github.com/user-attachments/assets/39274473-ceb3-48fb-a031-e22230decbe2)](https://github.com/mco-org/mco)
@@ -164,6 +176,9 @@ MCO equips your primary agent with an agent team that can work together to solve
 [Code](https://github.com/mco-org/mco)
 
 </td>
+</tr>
+
+<tr>
 <td width="50%" valign="top">
 
 [![banner-gif](https://github.com/user-attachments/assets/314c9126-8e08-4688-bbbb-8555ad58cf67)](https://github.com/onenewborn/StudyBuddy-public)
@@ -175,9 +190,6 @@ Study proactively with an agent that has self-evolving memory.
 [Code](https://github.com/onenewborn/StudyBuddy-public)
 
 </td>
-</tr>
-
-<tr>
 <td width="50%" valign="top">
 
 [![banner-gif](https://github.com/user-attachments/assets/21da76aa-9a8b-48e0-9134-42429d7390e7)](https://github.com/TonyLiangDesign/MemoCare)
@@ -189,6 +201,9 @@ Empowering individuals with advanced memory support and daily assistance.
 [Code](https://github.com/TonyLiangDesign/MemoCare)
 
 </td>
+</tr>
+
+<tr>
 <td width="50%" valign="top">
 
 [![banner-gif](https://github.com/user-attachments/assets/e2428df3-ea11-4e88-8f9c-dad437dd8998)](https://github.com/AlexL1024/NeuralConnect)
@@ -200,9 +215,6 @@ An iOS sci-fi mystery game where players explore and uncover the truth.
 [Code](https://github.com/AlexL1024/NeuralConnect)
 
 </td>
-</tr>
-
-<tr>
 <td width="50%" valign="top">
 
 [![banner-gif](https://github.com/user-attachments/assets/e6eaf308-a874-483f-8874-6934bf95a78f)](https://github.com/elontusk5219-prog/Mobi)
@@ -214,6 +226,9 @@ An iOS app where users create, nurture, and live with a personalized AI companio
 [Code](https://github.com/elontusk5219-prog/Mobi)
 
 </td>
+</tr>
+
+<tr>
 <td width="50%" valign="top">
 
 [![banner-gif](https://github.com/user-attachments/assets/9aabcaa9-f97a-49d2-9109-0b5bb696ed41)](https://github.com/JaMesLiMers/EvermemCompetition-Spiro)
@@ -225,8 +240,6 @@ A context-native AI wearable that listens to everyday life and converts conversa
 [Code](https://github.com/JaMesLiMers/EvermemCompetition-Spiro)
 
 </td>
-</tr>
-<tr>
 <td width="50%" valign="top">
 
 [![banner-gif](https://github.com/user-attachments/assets/df9677ec-386f-4c56-a428-08bca25c54dc)](../docs/migration-to-1.0.0.md)
@@ -238,6 +251,9 @@ Archived pre-1.0.0 plugin reference. New integrations should use the EverOS 1.0.
 [Learn more](../docs/migration-to-1.0.0.md)
 
 </td>
+</tr>
+
+<tr>
 <td width="50%" valign="top">
 
 [![banner-gif](https://github.com/user-attachments/assets/3a2357a1-c0c3-464a-8979-0d1cdfc9b0d4)](https://github.com/TEN-framework/ten-framework/tree/04cb80601374fa9e35b4e544b2dbd23286ca7763/ai_agents/agents/examples/voice-assistant-with-EverMemOS)
@@ -249,8 +265,6 @@ Add long-term memory to a real-time Live2D character, powered by [TEN Framework]
 [Code](https://github.com/TEN-framework/ten-framework/tree/04cb80601374fa9e35b4e544b2dbd23286ca7763/ai_agents/agents/examples/voice-assistant-with-EverMemOS)
 
 </td>
-</tr>
-<tr>
 <td width="50%" valign="top">
 
 [![banner-gif](https://github.com/user-attachments/assets/c36bdc04-97d3-4fe9-97d9-4b93b475595a)](https://screenshot-analysis-vercel.vercel.app/)
@@ -262,6 +276,9 @@ Run screenshot-based analysis with computer-use and store the results in memory.
 [Live Demo](https://screenshot-analysis-vercel.vercel.app/)
 
 </td>
+</tr>
+
+<tr>
 <td width="50%" valign="top">
 
 [![banner-gif](https://github.com/user-attachments/assets/54a7cf8f-62c4-4fbc-9d50-b214d034e051)](game-of-throne-demo)
@@ -273,8 +290,6 @@ A demonstration of AI memory infrastructure through an interactive Q&A experienc
 [Code](game-of-throne-demo)
 
 </td>
-</tr>
-<tr>
 <td width="50%" valign="top">
 
 [![banner-gif](https://github.com/user-attachments/assets/af37c1f6-7ba5-430c-b99d-2a7e7eac618f)](claude-code-plugin)
@@ -286,6 +301,9 @@ Persistent memory for Claude Code. Automatically saves and recalls context from 
 [Code](claude-code-plugin)
 
 </td>
+</tr>
+
+<tr>
 <td width="50%" valign="top">
 
 [![banner-gif](https://github.com/user-attachments/assets/d521d28c-0ccd-44ff-aecc-828245e2f973)](https://main.d2j21qxnymu6wl.amplifyapp.com/graph.html)
@@ -297,6 +315,7 @@ Explore stored entities and relationships in a graph interface. Frontend demo; b
 [Live Demo](https://main.d2j21qxnymu6wl.amplifyapp.com/graph.html)
 
 </td>
+<td width="50%" valign="top"></td>
 </tr>
 </table>
 


### PR DESCRIPTION
## Summary

Add [AIUI Sports Agents](https://github.com/EasonZhu1997/AIUI-Sports-Agents) as the first use case in the English and Chinese READMEs and both dedicated galleries. The new 1300 × 553 banner follows the existing card style and is hosted on GitHub user-attachments.

The description scopes optional memory integration to AISmartRun's backend contract. Existing cards retain their content and order as the two-column grid shifts forward.

Closes #435

## Area

- [ ] Architecture method
- [ ] Benchmark
- [x] Use case
- [x] Documentation
- [ ] Developer experience
- [ ] CI, build, or release

## Verification

- `make docs-check` — passed.
- Repository asset, file-size, and deprecated-name checks — passed.
- Gallery structural check — AIUI first in all four files; all 24 existing cards preserved in order; balanced two-column rows.
- GitHub rendered README — banner loads and aligns with Reunite in the first row; image and Code link target the project repository.
- Public attachment download matches the original SHA-256.
- `make ci` — passed: lint; 2092 unit tests; 183 integration tests (7 deselected by the repository configuration); sdist/wheel build and wheel-import smoke test.

## Checklist

- [x] I kept the change scoped to the relevant area.
- [x] I am opening this from a separate branch, not pushing directly to `main`.
- [x] I updated docs, examples, or setup notes when behavior changed.
- [x] I added or updated tests when the change affects behavior. (Documentation only; no runtime behavior change.)
- [x] I did not commit secrets, `.env` files, dependency folders, or generated output.
- [x] Active relative links in Markdown files resolve.

## Notes for Reviewers

![AIUI Sports Agents for Smart Glasses](https://github.com/user-attachments/assets/7a8e6bca-6a12-4284-aa57-2f59fed7a6a2)

By submitting this pull request, I agree that my contribution is licensed under the Apache License 2.0.
