### PR TITLE
chore(release): v1.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,93 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.3.0] - 2026-09-07
+
+**Milvus as an optional index backend, behind a port that hides which one you
+run.** The rebuildable BM25/vector index can now live in a remote Milvus Server
+or Zilliz Cloud instead of the embedded LanceDB, selected by one setting and
+verified at startup. Nothing about the default installation changes: LanceDB
+stays the backend, `pymilvus` stays an optional extra, and markdown stays the
+source of truth — the index is derived either way, so switching backends is a
+rebuild, not a migration. Both backends implement the same typed ports, so
+cascade, search and `/get` never branch on physical storage; a filter is a
+backend-neutral predicate tree rather than a rendered SQL string, which is what
+lets one set of contract tests hold both adapters to the same behaviour. The
+vector metric is now cosine everywhere, which corrects an inconsistency
+described under Changed.
+
+### Added
+
+- **Optional Milvus derived-index backend.** Install with
+  `pip install everos[milvus]` and select it with:
+
+  ```toml
+  [index]
+  backend = "milvus"
+
+  [milvus]
+  uri = "http://127.0.0.1:19530"   # or a Zilliz Cloud endpoint
+  token = ""                        # Zilliz Cloud API key
+  db_name = ""
+  consistency_level = "Session"     # Strong | Bounded | Session | Eventually
+  collection_prefix = "everos"
+  ```
+
+  Every field binds to an environment variable
+  (`EVEROS_INDEX__BACKEND`, `EVEROS_MILVUS__URI`, ...). The seven business
+  tables are created as `<collection_prefix>_<kind>`.
+
+  **Remote Milvus Server or Zilliz Cloud only.** A local database path is
+  rejected at startup rather than silently accepted: embedded Milvus Lite is
+  not supported, because its pure-Python rewrite degrades a single query to a
+  full scan and drops search-time parameters.
+
+  Startup verifies the physical collection field by field — datatype, primary
+  key, nullability, vector dimension, and the index metric (dense `COSINE`,
+  BM25 output fields) — so a collection that disagrees with the declared schema
+  fails immediately instead of at the first write or search.
+
+### Changed
+
+- **Vector search now uses cosine distance on LanceDB too.** The generic
+  vector path called `nearest_to()` without a distance type, so it ran on
+  LanceDB's L2 default while `agent_skill` recall and every Milvus query
+  already used cosine. All of them are cosine now. **Ranking can shift for
+  existing deployments** — the same vectors are scored by a different metric.
+  No action is required and no rebuild is involved; the index is unchanged.
+- **everalgo's transitive layer is pinned.** `everalgo-boundary`,
+  `everalgo-core` and `everalgo-clustering` are now direct `==` dependencies
+  matching the versions the test suite resolves. The consumer packages declare
+  them as `>=0.2.0,<2.0.0`, which treats a 0.x line as if only a major bump
+  could break compatibility, so a fresh resolution could pick releases the
+  suite had never run against. Raise them deliberately, together with a smoke
+  run against a PyPI-resolved install — `make package` installs the built
+  wheel with `--no-deps`, so it cannot catch a resolution break on its own.
+
+### Fixed
+
+- **`POST /api/v1/memory/add` no longer fails on a freshly resolved install.**
+  `everalgo-boundary` 0.3.0 added a third required field to the public
+  `DetectionResult` NamedTuple while `everalgo-agent-memory` 0.4.0 still built
+  it with two, so a default (`memorize.mode = "agent"`) install answered
+  `500 TypeError: DetectionResult.__new__() missing 1 required positional
+  argument: 'should_wait'`. Chat mode was unaffected. The pin above resolves
+  the compatible pair.
+- **Milvus datetime round-trips are exact below the millisecond threshold.**
+  Timestamps were written in milliseconds but read back through a
+  seconds-or-milliseconds heuristic, so any instant before 2001-09-09 either
+  landed in the year 30000 or raised `ValueError`. Physical column reads now
+  use an exact inverse.
+- **Concurrent `update()` on the Milvus backend no longer loses writes.** The
+  read half of the read-modify-write cycle sat outside the write lock, so a
+  backfill writing `vector` and a reflection writing `deprecated_by` could
+  overwrite each other on the same row. Both halves share one lock, and the
+  silent 10,000-row truncation on that path is gone.
+- **Milvus queries stay inside the engine's result window.** Row scans and
+  search `topK` are bounded by the 16,384-row ceiling instead of requesting
+  more and failing.
+
+
 ## [1.2.3] - 2026-08-07
 
 **Background maintenance that fails loudly instead of quietly.** A soak run on
@@ -946,7 +1033,7 @@ for AI agents.
 - **Decoupled algorithms** — memory extraction algorithms live in the standalone
   `everalgo-*` libraries published on PyPI.
 
-[Unreleased]: https://github.com/EverMind-AI/everos/compare/v1.1.4...HEAD
+[Unreleased]: https://github.com/EverMind-AI/everos/compare/v1.3.0...HEAD
 [1.1.4]: https://github.com/EverMind-AI/everos/compare/v1.1.3...v1.1.4
 [1.1.3]: https://github.com/EverMind-AI/everos/compare/v1.1.2...v1.1.3
 [1.1.2]: https://github.com/EverMind-AI/everos/compare/v1.1.1...v1.1.2

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "everos",
     "description": "md-first memory extraction framework",
-    "version": "1.3.0rc1"
+    "version": "1.3.0"
   },
   "paths": {
     "/health": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "everos"
-version = "1.3.0rc1"
+version = "1.3.0"
 description = "EverOS — local-first markdown memory framework for AI agents and user chats; lightweight, dev-friendly, small-team"
 license = {text = "Apache-2.0"}
 readme = "README.md"

--- a/uv.lock
+++ b/uv.lock
@@ -579,7 +579,7 @@ wheels = [
 
 [[package]]
 name = "everos"
-version = "1.3.0rc1"
+version = "1.3.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
Promotes `1.3.0rc1` to the stable line. The RC existed to verify one thing that no gate in this repo can: that a real PyPI resolution — not `uv.lock` — produces a working install. `make package` installs the built wheel with `--no-deps`, so the release pipeline's own smoke is blind to a resolution break, which is how 1.2.3 shipped with `POST /add` answering 500.

## Changes

| File | Change |
|---|---|
| `CHANGELOG.md` | `## [1.3.0]` section; `[Unreleased]` link moved off v1.1.4 (three releases stale) to v1.3.0 |
| `pyproject.toml` | `version = "1.3.0"` |
| `docs/openapi.json` | regenerated — `info.version` tracks `everos.__version__`, and `make lint` fails on a stale dump |
| `uv.lock` | project version |

## No `### Upgrade` group

Deliberate, per the release skill's "omit the group entirely when a plain `pip install --upgrade` is all there is". Verified rather than assumed: `git diff v1.2.3..main -- src/everos/infra/persistence/lancedb/tables/` is empty, so the physical LanceDB schema is unchanged and no rebuild is involved. The vector-metric change (L2 → cosine on the generic LanceDB path, which was already cosine for `agent_skill` and on Milvus) is documented under Changed — it shifts ranking but requires no action, and the boilerplate `## Upgrade` the workflow appends carries the plain upgrade line.

## RC verification (against the package installed from PyPI)

Installed by exact pin (`everos==1.3.0rc1`), both installation paths, `everos init` → server → real interfaces:

| | default (LanceDB) | `[milvus]` extra |
|---|---|---|
| resolved `everalgo-boundary` / `httpx` | 0.2.1 / 0.28.1 | 0.2.1 / 0.28.1 |
| `DetectionResult._fields` | `('cells','tail')` | same |
| `/add` → `/flush` → cascade | all `extracted`, 0/0/0 | all `extracted`, 0/0/0 |
| `/get episode` | 3, subjects accurate | 3 |
| `/search` discrimination (4 methods x 3 unrelated topics) | 11/12 | 12/12 |
| owner isolation (unknown user) | 0 rows | 0 rows |

All seven memory kinds produce rows on the published artifact: `episode` 6, `atomic_fact` 80, `foresight` 38, `agent_case` 5, `agent_skill` 5, `user_profile` 1, `knowledge_topic` 17.

The single LanceDB miss is `keyword` x one topic: that episode was extracted in Spanish from English input, so English BM25 terms cannot reach it. Known LLM instruction-following issue, unrelated to the index backend, absent from the Milvus run on the same input. Measured separately at 9/12 for that content and 0/12 for another — content-correlated, not random.