### PR TITLE
fix(config): move the multimodal default off a preview model

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -36,7 +36,7 @@ EVEROS_LLM__BASE_URL=https://openrouter.ai/api/v1
 # audio / ...); must support OpenAI image_url parts. Defaults target
 # Gemini via OpenRouter so the same key covers chat + multimodal.
 
-EVEROS_MULTIMODAL__MODEL=google/gemini-3-flash-preview
+EVEROS_MULTIMODAL__MODEL=google/gemini-3.8-flash
 EVEROS_MULTIMODAL__API_KEY=
 EVEROS_MULTIMODAL__BASE_URL=https://openrouter.ai/api/v1
 # Concurrency cap for parallel multimodal calls (default 4):

--- a/README.md
+++ b/README.md
@@ -273,7 +273,7 @@ uv pip install 'everos[multimodal]'   # or: pip install 'everos[multimodal]'
 
 This pulls in `everalgo-parser` (with the `[svg]` bundle for SVG support via
 cairosvg). Configure the `[multimodal]` section in `everos.toml`; its default
-model is `google/gemini-3-flash-preview` via OpenRouter.
+model is `google/gemini-3.8-flash` via OpenRouter.
 
 **Office document support requires LibreOffice as a system dependency.**
 The parser shells out to `soffice` (LibreOffice's headless renderer) to

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -275,7 +275,7 @@ uv pip install 'everos[multimodal]'   # or: pip install 'everos[multimodal]'
 
 这会引入 `everalgo-parser`（包含用于 SVG 支持的 `[svg]` bundle，通过
 cairosvg）。在 `everos.toml` 的 `[multimodal]` 中完成配置；默认模型是通过
-OpenRouter 使用的 `google/gemini-3-flash-preview`。
+OpenRouter 使用的 `google/gemini-3.8-flash`。
 
 **Office 文档支持需要 LibreOffice 作为系统依赖。** parser 会调用
 `soffice`（LibreOffice 的 headless renderer），先把 `.doc` / `.docx` /

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -134,7 +134,7 @@ Zilliz Cloud endpoint; a Milvus Lite filesystem path is rejected.
 
 | Field | Type | Default | Required | Description |
 |---|---|---|---|---|
-| `model` | string | `"google/gemini-3-flash-preview"` | No | Multimodal parsing model. |
+| `model` | string | `"google/gemini-3.8-flash"` | No | Multimodal parsing model. |
 | `api_key` | string | — | **Yes** | API key. |
 | `base_url` | string | — | No | Custom endpoint URL. |
 | `max_concurrency` | int | `4` | No | Max parallel parsing requests. |

--- a/docs/multimodal.md
+++ b/docs/multimodal.md
@@ -97,7 +97,7 @@ parts. Fill in three fields in `everos.toml`:
 
 ```toml
 [multimodal]
-model    = "google/gemini-3-flash-preview"   # must support image_url parts
+model    = "google/gemini-3.8-flash"   # must support image_url parts
 base_url = "https://openrouter.ai/api/v1"
 api_key  = "<your key>"
 ```
@@ -270,7 +270,7 @@ containers and CI).
 
 | Field | Default | Meaning |
 |---|---|---|
-| `model` | `google/gemini-3-flash-preview` | Parsing model; must accept `image_url` parts |
+| `model` | `google/gemini-3.8-flash` | Parsing model; must accept `image_url` parts |
 | `base_url` | `https://openrouter.ai/api/v1` | OpenAI-compatible base URL |
 | `api_key` | — (required) | API key for the endpoint above |
 | `max_concurrency` | `4` | Cap on parallel multimodal calls within one extraction |

--- a/src/everos/config/default.toml
+++ b/src/everos/config/default.toml
@@ -112,7 +112,7 @@ fallback_core = 3              # core size when every decider attempt fails
 # Independent LLM for multimodal parsing (everalgo-parser); must accept
 # image / pdf / audio image_url parts. Override via env:
 #   EVEROS_MULTIMODAL__MODEL, EVEROS_MULTIMODAL__API_KEY, EVEROS_MULTIMODAL__BASE_URL
-model = "google/gemini-3-flash-preview"
+model = "google/gemini-3.8-flash"
 api_key = ""
 base_url = "https://openrouter.ai/api/v1"
 max_concurrency = 4

--- a/src/everos/config/settings.py
+++ b/src/everos/config/settings.py
@@ -333,7 +333,7 @@ class MultimodalSettings(BaseModel):
         EVEROS_MULTIMODAL__FILE_URI_MAX_BYTES
     """
 
-    model: str = "google/gemini-3-flash-preview"
+    model: str = "google/gemini-3.8-flash"
     api_key: SecretStr | None = None
     base_url: str | None = None
     max_concurrency: int = 4

--- a/src/everos/templates/env.template
+++ b/src/everos/templates/env.template
@@ -36,7 +36,7 @@ EVEROS_LLM__BASE_URL=https://openrouter.ai/api/v1
 # audio / ...); must support OpenAI image_url parts. Defaults target
 # Gemini via OpenRouter so the same key covers chat + multimodal.
 
-EVEROS_MULTIMODAL__MODEL=google/gemini-3-flash-preview
+EVEROS_MULTIMODAL__MODEL=google/gemini-3.8-flash
 EVEROS_MULTIMODAL__API_KEY=
 EVEROS_MULTIMODAL__BASE_URL=https://openrouter.ai/api/v1
 # Concurrency cap for parallel multimodal calls (default 4):


### PR DESCRIPTION
## Summary

The shipped multimodal default was `google/gemini-3-flash-preview`. Preview
listings can be withdrawn from the router without notice, which would take every
default-config multimodal install down with it. `google/gemini-3.8-flash` is the
generally available line.

The reason for this change is the `preview` tag, not the version number — a
newer preview would be no safer.

Updates every place the id is written out, not just the shipped default:

| File | What it is |
|---|---|
| `src/everos/config/default.toml` | shipped default |
| `src/everos/config/settings.py` | `MultimodalSettings.model` fallback |
| `README.md`, `README.zh-CN.md` | recommended model |
| `docs/configuration.md`, `docs/multimodal.md` | config table + example |
| `.env.example`, `src/everos/templates/env.template` | env scaffolding |

## Area

- [ ] Architecture method
- [ ] Benchmark
- [ ] Use case
- [ ] Documentation
- [x] Developer experience
- [ ] CI, build, or release

## Verification

```text
uv run pytest tests/unit/test_config -q  -> 22 passed
uv run pytest tests/unit -q              -> 2144 passed
make lint                                -> clean, 4 contracts kept
```

The parser requires a model that accepts `image_url` content parts, so that was
checked against the live endpoint rather than assumed: a data-URI PNG sent to
`google/gemini-3.8-flash` through OpenRouter came back with the correct answer.

Scope of that check: `image` only. The surrounding comment also claims `pdf` and
`audio`; those were not exercised. That claim predates this change and applies
equally to the outgoing default, so it is not a regression — but it is also not
verified.

## Checklist

- [x] I kept the change scoped to the relevant area.
- [x] I am opening this from a separate branch, not pushing directly to `main`.
- [x] I updated docs, examples, or setup notes when behavior changed.
- [ ] I added or updated tests when the change affects behavior.
- [x] I did not commit secrets, `.env` files, dependency folders, or generated output.
- [x] Active relative links in Markdown files resolve.

No new test: `test_embedding_rerank_defaults` and friends already pin the config
surface, and a test asserting one model id against another is a tautology that
would need editing on every future bump.

## Notes for Reviewers

Existing installs are unaffected — anyone with an explicit `[multimodal] model`
in their `everos.toml` or `EVEROS_MULTIMODAL__MODEL` keeps it. This only moves
the fallback.

Worth confirming you want 3.8 rather than an older GA release; I took the newest
generally available flash line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)