### PR TITLE
docs(rerank): document DashScope provider

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -157,7 +157,7 @@ Zilliz Cloud endpoint; a Milvus Lite filesystem path is rejected.
 
 | Field | Type | Default | Required | Description |
 |---|---|---|---|---|
-| `provider` | string | `"deepinfra"` | No | Rerank provider: `deepinfra` or `vllm`. |
+| `provider` | string | `"deepinfra"` | No | Rerank provider: `deepinfra`, `vllm`, or `dashscope`. |
 | `model` | string | — | **Yes** | Reranker model identifier. |
 | `api_key` | string | — | **Yes** | API key. |
 | `base_url` | string | — | **Yes** | Rerank endpoint URL. |

--- a/src/everos/component/rerank/factory.py
+++ b/src/everos/component/rerank/factory.py
@@ -35,8 +35,8 @@ def build_rerank_provider(settings: RerankSettings) -> RerankProvider:
     Raises:
         ValueError: If ``model`` or ``base_url`` is unset, or if
             ``provider`` does not match a known implementation.
-            ``api_key`` is required for ``deepinfra``; optional (empty
-            string) for ``vllm`` self-hosted endpoints.
+            ``api_key`` is required for ``deepinfra`` and ``dashscope``;
+            optional (empty string) for ``vllm`` self-hosted endpoints.
     """
     if not settings.model:
         raise ValueError(missing_config_error("Rerank model", "rerank"))


### PR DESCRIPTION
## Summary

* Document `dashscope` as a supported `[rerank].provider` alongside `deepinfra` and `vllm`.
* Clarify in `build_rerank_provider` that `api_key` is required for both DeepInfra and DashScope, while it remains optional for self-hosted vLLM endpoints.
* No runtime behavior changes.

## Area

* [ ] Architecture method
* [ ] Benchmark
* [ ] Use case
* [x] Documentation
* [ ] Developer experience
* [ ] CI, build, or release

## Verification

```text
Python AST parse of the updated factory.py: passed
Configuration table structure/provider-name check: passed
Branch diff: 1 commit, 2 files; documentation/docstring changes only
```

Repo-wide `make ci` was not run because the execution environment could not create a working-tree checkout. The change does not alter runtime behavior.

## Checklist

* [x] I kept the change scoped to the relevant area.
* [x] I am opening this from a separate branch, not pushing directly to `main`.
* [x] I updated docs, examples, or setup notes when behavior changed.
* [x] Tests are not applicable because this change does not affect behavior.
* [x] I did not commit secrets, `.env` files, dependency folders, or generated output.
* [x] No Markdown links were added or changed.

## Notes for Reviewers

`RerankSettings` and the provider factory already support DashScope; this PR only brings the configuration reference and the factory docstring in sync with the existing implementation.

By submitting this pull request, I agree that my contribution is licensed under
the Apache License 2.0.
